### PR TITLE
Add zipkin.tracing_override and zipkin.post_logging_hook

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+0.7.0 (2016-02-23)
+------------------
+- Add `tracing_override` and `post_logging_hook` settings.
+
 0.6.0 (2016-02-06)
 ------------------
 - Fix bug which was squashing identical span names.

--- a/docs/source/configuring_zipkin.rst
+++ b/docs/source/configuring_zipkin.rst
@@ -103,7 +103,7 @@ fine tune as per your use case.
 5. zipkin.trace_id_generator
 ----------------------------
     A method definition to generate a `trace_id` for the request. By default,
-    it creates a randon trace id otherwise.
+    it creates a random trace id otherwise.
 
     The method MUST take `request` as a parameter (so that you can make trace
     id deterministic).
@@ -125,6 +125,36 @@ fine tune as per your use case.
         settings['zipkin.set_extra_binary_annotations'] = set_binary_annotations
 
 
+7. zipkin.tracing_override
+--------------------------
+    A method that takes a `request` parameter and returns True if the request should be traced.
+    Note that this override function does not override blacklisted paths/routes. If this function
+    returns False, the request may still be traced according to the tracing percentage. Example:
+
+    .. code-block:: python
+
+        def custom_override_func(request):
+            # ...
+            return True
+            # else, return False
+
+        settings['zipkin.tracing_override'] = custom_override_func
+
+
+8. zipkin.post_logging_hook
+---------------------------
+    A method that takes a `request` parameter and is called after the trace is logged and before
+    the zipkin context exits. This gives the ability to execute custom code after the zipkin
+    context manager successfully logs a trace.
+
+    .. code-block:: python
+
+        def post_logging_hook(request):
+            # custom logic, clean-up tasks, etc.
+
+        settings['zipkin.post_logging_hook'] = post_logging_hook
+
+
 These settings can be added like so:
 
 .. code-block:: python
@@ -135,6 +165,8 @@ These settings can be added like so:
             settings['zipkin.blacklisted_routes'] = ['bar']
             settings['zipkin.trace_id_generator'] = lambda req: '0x42'
             settings['zipkin.set_extra_binary_annotations'] = lambda req, resp: {'attr': str(req.attr)}
+            settings['zipkin.tracing_override'] = lambda req: False
+            settings['zipkin.post_logging_hook'] = lambda req: None
             # ...and so on with the other settings...
             config = Configurator(settings=settings)
             config.include('zipkin')

--- a/pyramid_zipkin/request_helper.py
+++ b/pyramid_zipkin/request_helper.py
@@ -30,7 +30,7 @@ def generate_random_64bit_string():
     return codecs.encode(os.urandom(8), 'hex_codec')
 
 
-def thrift_compatble_string(token_id):
+def thrift_compatible_string(token_id):
     """Converts token to a thrift compatible 64bit string"""
     # Zipkin passes unsigned values in signed types because Thrift has no
     # unsigned types, so we have to convert the value.
@@ -43,7 +43,7 @@ def generate_span_id():
 
     :returns: string representation of zipkin span id
     """
-    return thrift_compatble_string(generate_random_64bit_string())
+    return thrift_compatible_string(generate_random_64bit_string())
 
 
 def get_trace_id(request):
@@ -59,7 +59,7 @@ def get_trace_id(request):
     elif 'zipkin.trace_id_generator' in request.registry.settings:
         return request.registry.settings['zipkin.trace_id_generator'](request)
     else:
-        return thrift_compatble_string(generate_random_64bit_string())
+        return thrift_compatible_string(generate_random_64bit_string())
 
 
 def should_not_sample_path(request):

--- a/pyramid_zipkin/request_helper.py
+++ b/pyramid_zipkin/request_helper.py
@@ -147,7 +147,6 @@ def create_zipkin_attr(request):
     trace_id = request.zipkin_trace_id
     is_sampled = is_tracing(request)
     span_id = request.headers.get('X-B3-SpanId', generate_span_id())
-    request.headers['X-B3-SpanId'] = span_id
     parent_span_id = request.headers.get('X-B3-ParentSpanId', '0')
     flags = request.headers.get('X-B3-Flags', '0')
     return ZipkinAttrs(trace_id=trace_id, span_id=span_id,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 setup(
     name='pyramid_zipkin',

--- a/tests/acceptance/client_span_test.py
+++ b/tests/acceptance/client_span_test.py
@@ -43,15 +43,18 @@ def test_headers_created_for_sampled_child_span(sampled_trace_id_generator):
 
     expected = {
         'X-B3-Flags': '0',
-        'X-B3-ParentSpanId': '1',
+        'X-B3-ParentSpanId': '0x1234',
         'X-B3-Sampled': '1',
         'X-B3-TraceId': '0x0',
         }
 
-    headers = TestApp(main({}, **settings)).get('/sample_child_span',
-                                                status=200)
+    with mock.patch('pyramid_zipkin.request_helper.generate_span_id') \
+            as mock_generate_span_id:
+        mock_generate_span_id.return_value = '0x1234'
+        headers = TestApp(main({}, **settings)).get('/sample_child_span',
+                                                    status=200)
     headers_json = headers.json
-    headers_json.pop('X-B3-SpanId')  # Randomnly generated - Ignore.
+    headers_json.pop('X-B3-SpanId')  # Randomly generated - Ignore.
 
     assert expected == headers_json
 
@@ -66,12 +69,15 @@ def test_headers_created_for_unsampled_child_span(default_trace_id_generator):
         'X-B3-Flags': '0',
         'X-B3-Sampled': '0',
         'X-B3-TraceId': '0x42',
-        'X-B3-ParentSpanId': '1',
+        'X-B3-ParentSpanId': '0x1234',
         }
 
-    headers = TestApp(main({}, **settings)).get('/sample_child_span',
-                                                status=200)
+    with mock.patch('pyramid_zipkin.request_helper.generate_span_id') \
+            as mock_generate_span_id:
+        mock_generate_span_id.return_value = '0x1234'
+        headers = TestApp(main({}, **settings)).get('/sample_child_span',
+                                                    status=200)
     headers_json = headers.json
-    headers_json.pop('X-B3-SpanId')  # Randomnly generated - Ignore.
+    headers_json.pop('X-B3-SpanId')  # Randomly generated - Ignore.
 
     assert expected == headers_json

--- a/tests/acceptance/server_span_test.py
+++ b/tests/acceptance/server_span_test.py
@@ -29,7 +29,10 @@ def test_sample_server_span_with_100_percent_tracing(
 
     thrift_obj.side_effect = validate_span
 
-    TestApp(main({}, **settings)).get('/sample', status=200)
+    with mock.patch('pyramid_zipkin.request_helper.generate_span_id') \
+            as mock_generate_span_id:
+        mock_generate_span_id.return_value = '0x1'
+        TestApp(main({}, **settings)).get('/sample', status=200)
 
     assert thrift_obj.call_count == 1
 

--- a/tests/logging_helper_test.py
+++ b/tests/logging_helper_test.py
@@ -73,6 +73,7 @@ def test_zipkin_logging_context_stores_start_timestamp_on_entry(
             autospec=True)
 def test_zipkin_logging_context_pops_zikin_attr_from_thread_local_on_exit(
         pop_mock, logger, context):
+    context.registry_settings = {}
     context.__exit__('_', '_', '_')
     pop_mock.assert_called_once_with()
 
@@ -80,6 +81,7 @@ def test_zipkin_logging_context_pops_zikin_attr_from_thread_local_on_exit(
 @mock.patch('pyramid_zipkin.logging_helper.zipkin_logger', autospec=True)
 def test_zipkin_logging_context_removes_log_handler_on_exit(
         logger, context):
+    context.registry_settings = {}
     context.__exit__('_', '_', '_')
     logger.removeHandler.assert_called_once_with(context.handler)
 
@@ -89,8 +91,18 @@ def test_zipkin_logging_context_removes_log_handler_on_exit(
             autospec=True)
 def test_zipkin_logging_context_doesnt_log_if_span_not_sampled(
         log_span, _, context):
+    context.registry_settings = {}
     context.__exit__('_', '_', '_')
     assert 0 == log_span.call_count
+
+
+@mock.patch('pyramid_zipkin.logging_helper.zipkin_logger', autospec=True)
+def test_zipkin_logging_context_calls_post_logging_hook(
+        logger, context):
+    post_logging_hook = mock.Mock()
+    context.registry_settings = {'zipkin.post_logging_hook': post_logging_hook}
+    context.__exit__('_', '_', '_')
+    post_logging_hook.assert_called_once_with(context.request)
 
 
 @mock.patch('pyramid_zipkin.logging_helper.annotation_list_builder',

--- a/tests/request_helper_test.py
+++ b/tests/request_helper_test.py
@@ -135,7 +135,7 @@ def test_get_trace_id_runs_custom_trace_id_generator_if_present(request):
     assert 'foo' == request_helper.get_trace_id(request)
 
 
-@mock.patch('pyramid_zipkin.request_helper.thrift_compatble_string',
+@mock.patch('pyramid_zipkin.request_helper.thrift_compatible_string',
             autospec=True)
 def test_get_trace_id_returns_some_random_id_by_default(compat, request):
     compat.return_value = 'foo'


### PR DESCRIPTION
This adds 2 custom registry settings:

zipkin.tracing_override: Expected to be a function that returns True or False. This will force the request to be traced. Having this override function allows users to specify custom override logic in their application.

zipkin.post_logging_hook: A function that is run after logging is done in the zipkin logging context manager. This gives users the ability to execute custom code within the context of the zipkin logger.

Also, if the X-B3-SpanId header is not found in the request, a new span ID is generated with generate_span_id() instead of defaulting to "1".