### PR TITLE
Don't recompile blacklisted path regexes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+0.7.1 (2016-02-26)
+------------------
+- Don't re-compile path regexes
+
 0.7.0 (2016-02-24)
 ------------------
 - Don't enter ZipkinLoggingContext if request is not sampled.

--- a/docs/source/configuring_zipkin.rst
+++ b/docs/source/configuring_zipkin.rst
@@ -74,8 +74,8 @@ fine tune as per your use case.
 2. zipkin.blacklisted_paths
 ---------------------------
     A list of paths as strings, regex strings, or compiled regexes, any of which if matched with the
-    request path will not be sampled. Pre-compiled regexes will be the fastest. Won't behave well with
-    uncompiled unicode strings. Defaults to `[]`. Example:
+    request path will not be sampled. Pre-compiled regexes will be the fastest.
+    Defaults to `[]`. Example:
 
     .. code-block:: python
 

--- a/docs/source/configuring_zipkin.rst
+++ b/docs/source/configuring_zipkin.rst
@@ -70,10 +70,12 @@ fine tune as per your use case.
 ---------------------
     The `stream_name` the message will be logged to via transport layer. It defaults to `zipkin`.
 
+
 2. zipkin.blacklisted_paths
 ---------------------------
-    A list of paths as strings (accepts regex) any of which if matched with the
-    request path will not be sampled. Defaults to `[]`. Example:
+    A list of paths as strings, regex strings, or compiled regexes, any of which if matched with the
+    request path will not be sampled. Pre-compiled regexes will be the fastest. Won't behave well with
+    uncompiled unicode strings. Defaults to `[]`. Example:
 
     .. code-block:: python
 

--- a/pyramid_zipkin/request_helper.py
+++ b/pyramid_zipkin/request_helper.py
@@ -71,7 +71,12 @@ def should_not_sample_path(request):
     """
     blacklisted_paths = request.registry.settings.get(
         'zipkin.blacklisted_paths', [])
-    regexes = [re.compile(r) for r in blacklisted_paths]
+    # Only compile strings, since even recompiling existing
+    # compiled regexes takes time.
+    regexes = [
+        re.compile(r) if isinstance(r, str) else r
+        for r in blacklisted_paths
+    ]
     return any(r.match(request.path) for r in regexes)
 
 

--- a/pyramid_zipkin/request_helper.py
+++ b/pyramid_zipkin/request_helper.py
@@ -6,6 +6,7 @@ import re
 import struct
 from collections import namedtuple
 
+import six
 from pyramid.interfaces import IRoutesMapper
 
 
@@ -74,7 +75,7 @@ def should_not_sample_path(request):
     # Only compile strings, since even recompiling existing
     # compiled regexes takes time.
     regexes = [
-        re.compile(r) if isinstance(r, str) else r
+        re.compile(r) if isinstance(r, six.string_types) else r
         for r in blacklisted_paths
     ]
     return any(r.match(request.path) for r in regexes)

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     package_data = { '': [ '*.thrift' ] },
     install_requires = [
         'pyramid',
+        'six',
         'thriftpy',
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 setup(
     name='pyramid_zipkin',


### PR DESCRIPTION
Shaves a tiny bit of time off of processing a request. Apparently even re-compiling already compiled regexes takes time.