### PR TITLE
Generate span id by default if span id header is not present

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+0.8.1 (2016-03-02)
+------------------
+- Spans without a span ID will generate a new span ID by default.
+
 0.8.0 (2016-03-01)
 ------------------
 - Add ability to override "service_name" attribute when logging client

--- a/docs/source/configuring_zipkin.rst
+++ b/docs/source/configuring_zipkin.rst
@@ -103,7 +103,7 @@ fine tune as per your use case.
 5. zipkin.trace_id_generator
 ----------------------------
     A method definition to generate a `trace_id` for the request. By default,
-    it creates a randon trace id otherwise.
+    it creates a random trace id otherwise.
 
     The method MUST take `request` as a parameter (so that you can make trace
     id deterministic).

--- a/pyramid_zipkin/request_helper.py
+++ b/pyramid_zipkin/request_helper.py
@@ -30,7 +30,7 @@ def generate_random_64bit_string():
     return codecs.encode(os.urandom(8), 'hex_codec')
 
 
-def thrift_compatble_string(token_id):
+def thrift_compatible_string(token_id):
     """Converts token to a thrift compatible 64bit string"""
     # Zipkin passes unsigned values in signed types because Thrift has no
     # unsigned types, so we have to convert the value.
@@ -43,7 +43,7 @@ def generate_span_id():
 
     :returns: string representation of zipkin span id
     """
-    return thrift_compatble_string(generate_random_64bit_string())
+    return thrift_compatible_string(generate_random_64bit_string())
 
 
 def get_trace_id(request):
@@ -59,7 +59,7 @@ def get_trace_id(request):
     elif 'zipkin.trace_id_generator' in request.registry.settings:
         return request.registry.settings['zipkin.trace_id_generator'](request)
     else:
-        return thrift_compatble_string(generate_random_64bit_string())
+        return thrift_compatible_string(generate_random_64bit_string())
 
 
 def should_not_sample_path(request):
@@ -141,7 +141,7 @@ def create_zipkin_attr(request):
 
     trace_id = request.zipkin_trace_id
     is_sampled = is_tracing(request)
-    span_id = request.headers.get('X-B3-SpanId', '1')
+    span_id = request.headers.get('X-B3-SpanId', generate_span_id())
     parent_span_id = request.headers.get('X-B3-ParentSpanId', '0')
     flags = request.headers.get('X-B3-Flags', '0')
     return ZipkinAttrs(trace_id=trace_id, span_id=span_id,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 setup(
     name='pyramid_zipkin',

--- a/tests/acceptance/client_span_test.py
+++ b/tests/acceptance/client_span_test.py
@@ -65,18 +65,6 @@ def test_headers_not_created_for_unsampled_child_span(default_trace_id_generator
         'zipkin.trace_id_generator': default_trace_id_generator,
     }
 
-    # expected = {
-    #     'X-B3-Flags': '0',
-    #     'X-B3-Sampled': '0',
-    #     'X-B3-TraceId': '0x42',
-    #     'X-B3-ParentSpanId': '0x1234',
-    #     }
-
-    # with mock.patch('pyramid_zipkin.request_helper.generate_span_id') \
-    #         as mock_generate_span_id:
-    #     mock_generate_span_id.return_value = '0x1234'
-    #     headers = TestApp(main({}, **settings)).get('/sample_child_span',
-    #                                                 status=200)
     headers = TestApp(main({}, **settings)).get('/sample_child_span',
                                                 status=200)
     headers_json = headers.json

--- a/tests/acceptance/client_span_test.py
+++ b/tests/acceptance/client_span_test.py
@@ -43,13 +43,16 @@ def test_headers_created_for_sampled_child_span(sampled_trace_id_generator):
 
     expected = {
         'X-B3-Flags': '0',
-        'X-B3-ParentSpanId': '1',
+        'X-B3-ParentSpanId': '0x1234',
         'X-B3-Sampled': '1',
         'X-B3-TraceId': '0x0',
         }
 
-    headers = TestApp(main({}, **settings)).get('/sample_child_span',
-                                                status=200)
+    with mock.patch('pyramid_zipkin.request_helper.generate_span_id') \
+            as mock_generate_span_id:
+        mock_generate_span_id.return_value = '0x1234'
+        headers = TestApp(main({}, **settings)).get('/sample_child_span',
+                                                    status=200)
     headers_json = headers.json
     headers_json.pop('X-B3-SpanId')  # Randomnly generated - Ignore.
 
@@ -66,11 +69,14 @@ def test_headers_created_for_unsampled_child_span(default_trace_id_generator):
         'X-B3-Flags': '0',
         'X-B3-Sampled': '0',
         'X-B3-TraceId': '0x42',
-        'X-B3-ParentSpanId': '1',
+        'X-B3-ParentSpanId': '0x1234',
         }
 
-    headers = TestApp(main({}, **settings)).get('/sample_child_span',
-                                                status=200)
+    with mock.patch('pyramid_zipkin.request_helper.generate_span_id') \
+            as mock_generate_span_id:
+        mock_generate_span_id.return_value = '0x1234'
+        headers = TestApp(main({}, **settings)).get('/sample_child_span',
+                                                    status=200)
     headers_json = headers.json
     headers_json.pop('X-B3-SpanId')  # Randomnly generated - Ignore.
 

--- a/tests/acceptance/server_span_test.py
+++ b/tests/acceptance/server_span_test.py
@@ -29,7 +29,10 @@ def test_sample_server_span_with_100_percent_tracing(
 
     thrift_obj.side_effect = validate_span
 
-    TestApp(main({}, **settings)).get('/sample', status=200)
+    with mock.patch('pyramid_zipkin.request_helper.generate_span_id') \
+            as mock_generate_span_id:
+        mock_generate_span_id.return_value = '0x1'
+        TestApp(main({}, **settings)).get('/sample', status=200)
 
     assert thrift_obj.call_count == 1
 

--- a/tests/request_helper_test.py
+++ b/tests/request_helper_test.py
@@ -108,7 +108,7 @@ def test_get_trace_id_runs_custom_trace_id_generator_if_present(request):
     assert 'foo' == request_helper.get_trace_id(request)
 
 
-@mock.patch('pyramid_zipkin.request_helper.thrift_compatble_string',
+@mock.patch('pyramid_zipkin.request_helper.thrift_compatible_string',
             autospec=True)
 def test_get_trace_id_returns_some_random_id_by_default(compat, request):
     compat.return_value = 'foo'


### PR DESCRIPTION
Span IDs should not default to '1'. Instead, a new span ID should be generated if one doesn't exist.

This PR is a subset of the changes in PR #17.