### PR TITLE
Parent span id is None by default for root spans

### DIFF
--- a/pyramid_zipkin/request_helper.py
+++ b/pyramid_zipkin/request_helper.py
@@ -155,7 +155,7 @@ def create_zipkin_attr(request):
     trace_id = request.zipkin_trace_id
     is_sampled = is_tracing(request)
     span_id = request.headers.get('X-B3-SpanId', generate_random_64bit_string())
-    parent_span_id = request.headers.get('X-B3-ParentSpanId', '0' * 16)
+    parent_span_id = request.headers.get('X-B3-ParentSpanId', None)
     flags = request.headers.get('X-B3-Flags', '0')
     return ZipkinAttrs(
         trace_id=trace_id,

--- a/pyramid_zipkin/thrift_helper.py
+++ b/pyramid_zipkin/thrift_helper.py
@@ -124,14 +124,16 @@ def create_span(
     """Takes a bunch of span attributes and returns a thriftpy representation
     of the span.
     """
-    return zipkin_core.Span(**{
+    span_dict = {
         "trace_id": unsigned_hex_to_signed_int(trace_id),
         "name": span_name,
         "id": unsigned_hex_to_signed_int(span_id),
-        "parent_id": unsigned_hex_to_signed_int(parent_span_id),
         "annotations": annotations,
         "binary_annotations": binary_annotations,
-    })
+    }
+    if parent_span_id:
+        span_dict["parent_id"] = unsigned_hex_to_signed_int(parent_span_id)
+    return zipkin_core.Span(**span_dict)
 
 
 def thrift_obj_in_bytes(thrift_obj):  # pragma: no cover

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -52,7 +52,7 @@ def get_span(annotation, uri_binary_annotation, uri_qs_binary_annotation):
 
     return {'debug': False,
             'id': 1,
-            'parent_id': 0,
+            'parent_id': None,
             'duration': None,
             'timestamp': None,
             'annotations': sorted([sr_annotation, ss_annotation],


### PR DESCRIPTION
Fixes #33.

Tested this with zipkin_query version 1.39.3.