### PR TITLE
Add server annotations to ClientSpanContext, rename to SpanContext

### DIFF
--- a/pyramid_zipkin/logging_helper.py
+++ b/pyramid_zipkin/logging_helper.py
@@ -161,7 +161,7 @@ class ZipkinLoggerHandler(logging.StreamHandler, object):
         # If parent_span_id is set, the application is in a logging context
         # where each additional client span logged has this span as its parent.
         # This is to allow logging of hierarchies of spans instead of just
-        # single client spans. See the ClientSpanContext class.
+        # single client spans. See the SpanContext class.
         self.parent_span_id = None
         self.zipkin_attrs = zipkin_attrs
         self.client_spans = []
@@ -215,7 +215,7 @@ class ZipkinLoggerHandler(logging.StreamHandler, object):
             represent a new client span. If service_name is omitted, this is
             considered additional annotation for the currently active
             "parent span" (either the server span or the parent client span
-            inside a ClientSpanContext).
+            inside a SpanContext).
         """
         if not self.zipkin_attrs.is_sampled:
             return

--- a/tests/acceptance/app/__init__.py
+++ b/tests/acceptance/app/__init__.py
@@ -42,15 +42,15 @@ def sample_v2_client(request):
     return {}
 
 
-@view_config(route_name='client_context', renderer='json')
-def client_context(request):
+@view_config(route_name='span_context', renderer='json')
+def span_context(request):
     # These annotations should go to the server span
     zipkin_logger.debug({
         'annotations': {'server_annotation': 1},
         'binary_annotations': {'server': 'true'},
     })
-    # Creates a new client span child of the server span
-    with zipkin.ClientSpanContext(
+    # Creates a new span, a child of the server span
+    with zipkin.SpanContext(
         service_name='child', span_name='get',
         binary_annotations={'foo': 'bar'},
     ):
@@ -99,7 +99,7 @@ def main(global_config, **settings):
     config.add_route('sample_route_v2', '/sample_v2')
     config.add_route('sample_route_v2_client', '/sample_v2_client')
     config.add_route('sample_route_child_span', '/sample_child_span')
-    config.add_route('client_context', '/client_context')
+    config.add_route('span_context', '/span_context')
 
     config.add_route('server_error', '/server_error')
     config.add_route('client_error', '/client_error')

--- a/tests/acceptance/span_context_test.py
+++ b/tests/acceptance/span_context_test.py
@@ -81,7 +81,7 @@ def _assert_headers_present(settings, is_sampled):
 
 
 @mock.patch('pyramid_zipkin.logging_helper.thrift_obj_in_bytes', autospec=True)
-def test_client_context(
+def test_span_context(
     thrift_obj,
     sampled_trace_id_generator
 ):
@@ -91,7 +91,7 @@ def test_client_context(
         'zipkin.trace_id_generator': sampled_trace_id_generator,
     }
 
-    TestApp(main({}, **settings)).get('/client_context', status=200)
+    TestApp(main({}, **settings)).get('/span_context', status=200)
 
     # Ugly extraction of spans from mock thrift_obj call args
     # The order of span logging goes from innermost (grandchild) up.

--- a/tests/acceptance/span_context_test.py
+++ b/tests/acceptance/span_context_test.py
@@ -109,3 +109,14 @@ def test_span_context(
     assert_extra_binary_annotations(child_span, {'foo': 'bar', 'child': 'true'})
     assert_extra_annotations(grandchild_span, {'grandchild_annotation': 1000000})
     assert_extra_binary_annotations(grandchild_span, {'grandchild': 'true'})
+
+    # For the span produced by SpanContext, assert cs==sr and ss==cr
+    # Initialize them all so the equalities won't be true.
+    annotations = {
+        'cs': 0, 'sr': 1, 'ss': 2, 'cr': 3
+    }
+    for annotation in child_span.annotations:
+        if annotation.value in annotations:
+            annotations[annotation.value] = annotation.timestamp
+    assert annotations['cs'] == annotations['sr']
+    assert annotations['ss'] == annotations['cr']


### PR DESCRIPTION
Turns out that purely client spans (spans with 'cr' and 'cs' annotations but not 'ss' or 'sr') behave oddly when they have child spans. This is either due to a bug or a design quirk of the collector or cassandra schema. In any case, logging trees of spans in this context caused the parent client spans to inherit the service name of their children. This would result in trees of spans that looked like [this](http://yelp-shootie.appspot.com/shot/5022955629182976) instead of [this](http://yelp-shootie.appspot.com/shot/5642810728382464) (Yelp internal links).

I just added 'ss' and 'sr' annotations. Since this no longer made these spans "client spans", I also renamed ClientSpanContext to SpanContext and updated a bunch of comments. I also realized that this shouldn't be the first thing devs see when they open `zipkin.py`, so I moved the tween back to the top of the file.