### PR TITLE
Convert binary annotations vals to str

### DIFF
--- a/pyramid_zipkin/thrift_helper.py
+++ b/pyramid_zipkin/thrift_helper.py
@@ -108,9 +108,10 @@ def binary_annotation_list_builder(binary_annotations, host):
     """
     # TODO: Remove the type hard-coding of STRING to take it as a param option.
     ann_type = zipkin_core.AnnotationType.STRING
-    return [create_binary_annotation(
-        key, value, ann_type, host)
-        for key, value in binary_annotations.items()]
+    return [
+        create_binary_annotation(key, str(value), ann_type, host)
+        for key, value in binary_annotations.items()
+    ]
 
 
 def create_span(

--- a/tests/thrift_helper_test.py
+++ b/tests/thrift_helper_test.py
@@ -94,3 +94,10 @@ def test_binary_annotation_list_builder(bann_mock):
     bann_mock.assert_any_call('key1', 'val1', 6, 'host')
     bann_mock.assert_any_call('key2', 'val2', 6, 'host')
     assert bann_mock.call_count == 2
+
+
+def test_binary_annotation_list_builder_with_nonstring_values():
+    bann_list = {'test key': 5}
+    banns = thrift_helper.binary_annotation_list_builder(bann_list, 'host')
+    assert banns[0].key == 'test key'
+    assert banns[0].value == '5'


### PR DESCRIPTION
This wraps the binary annotation value in str() when building a list of binary annotations.

This enforces the fact that pyramid_zipkin only accepts string-type binary annotations. This will be updated later when support for the other AnnotationTypes (specified in zipkinCore.thrift) is added.

Resolves #24 