### PR TITLE
Add NullHandler to logging to prevent 'No handlers could be found for…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: 3472f2b3ce972de7b440a387a81c76f67d5539cd
+    sha: v0.5.1
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -11,4 +11,5 @@
     -   id: name-tests-test
     -   id: flake8
         exclude: docs/source/conf.py
+        args: ['--max-line-length=82']
     -   id: requirements-txt-fixer

--- a/pyramid_zipkin/logging_helper.py
+++ b/pyramid_zipkin/logging_helper.py
@@ -100,8 +100,7 @@ class ZipkinLoggingContext(object):
                 annotations = span['annotations']
                 annotations.update(annotations_by_span_id[span_id])
                 binary_annotations = span['binary_annotations']
-                binary_annotations.update(
-                    binary_annotations_by_span_id[span_id])
+                binary_annotations.update(binary_annotations_by_span_id[span_id])
                 # Create serializable thrift objects of annotations
                 thrift_annotations = annotation_list_builder(
                     annotations, endpoint
@@ -121,8 +120,7 @@ class ZipkinLoggingContext(object):
                 )
 
             # Collect extra annotations for server span, then log it.
-            extra_annotations = annotations_by_span_id[
-                self.zipkin_attrs.span_id]
+            extra_annotations = annotations_by_span_id[self.zipkin_attrs.span_id]
             extra_binary_annotations = binary_annotations_by_span_id[
                 self.zipkin_attrs.span_id
             ]
@@ -144,8 +142,7 @@ class ZipkinLoggingContext(object):
                 self.thrift_endpoint,
             )
 
-            span_name = "{0} {1}".format(
-                self.request_method, self.request_path)
+            span_name = "{0} {1}".format(self.request_method, self.request_path)
             log_span(
                 span_id=self.zipkin_attrs.span_id,
                 parent_span_id=self.zipkin_attrs.parent_span_id,
@@ -268,7 +265,8 @@ def get_binary_annotations(request, response):
     settings = request.registry.settings
     if 'zipkin.set_extra_binary_annotations' in settings:
         annotations.update(
-            settings['zipkin.set_extra_binary_annotations'](request, response))
+            settings['zipkin.set_extra_binary_annotations'](request, response)
+        )
     return annotations
 
 
@@ -295,4 +293,5 @@ def log_span(
         raise ZipkinError(
             "`zipkin.transport_handler` is a required config property, which"
             " is missing. It is a callback method which takes stream_name and"
-            " a message as the params and logs message via scribe/kafka.")
+            " a message as the params and logs message via scribe/kafka."
+        )

--- a/pyramid_zipkin/logging_helper.py
+++ b/pyramid_zipkin/logging_helper.py
@@ -13,7 +13,7 @@ from pyramid_zipkin.thrift_helper import thrift_obj_in_bytes
 
 try:  # Python 2.7+
     from logging import NullHandler
-except ImportError:
+except ImportError: # pragma: no cover
     class NullHandler(logging.Handler):
         def emit(self, record):
             pass

--- a/pyramid_zipkin/logging_helper.py
+++ b/pyramid_zipkin/logging_helper.py
@@ -13,8 +13,9 @@ from pyramid_zipkin.thrift_helper import thrift_obj_in_bytes
 
 try:  # Python 2.7+
     from logging import NullHandler
-except ImportError: # pragma: no cover
+except ImportError:  # pragma: no cover
     class NullHandler(logging.Handler):
+
         def emit(self, record):
             pass
 
@@ -34,6 +35,7 @@ class ZipkinLoggingContext(object):
     :type log_handler: :class:`pyramid_zipkin.logging_helper.ZipkinLoggerHandler`
     :param request: active pyramid request object
     """
+
     def __init__(self, zipkin_attrs, thrift_endpoint, log_handler, request):
         self.zipkin_attrs = zipkin_attrs
         self.thrift_endpoint = thrift_endpoint
@@ -98,7 +100,8 @@ class ZipkinLoggingContext(object):
                 annotations = span['annotations']
                 annotations.update(annotations_by_span_id[span_id])
                 binary_annotations = span['binary_annotations']
-                binary_annotations.update(binary_annotations_by_span_id[span_id])
+                binary_annotations.update(
+                    binary_annotations_by_span_id[span_id])
                 # Create serializable thrift objects of annotations
                 thrift_annotations = annotation_list_builder(
                     annotations, endpoint
@@ -118,7 +121,8 @@ class ZipkinLoggingContext(object):
                 )
 
             # Collect extra annotations for server span, then log it.
-            extra_annotations = annotations_by_span_id[self.zipkin_attrs.span_id]
+            extra_annotations = annotations_by_span_id[
+                self.zipkin_attrs.span_id]
             extra_binary_annotations = binary_annotations_by_span_id[
                 self.zipkin_attrs.span_id
             ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal = True
+
+[pep8]
+ignore = E265,E309,E501

--- a/tests/acceptance/app/__init__.py
+++ b/tests/acceptance/app/__init__.py
@@ -12,12 +12,12 @@ zipkin_logger = logging.getLogger('pyramid_zipkin.logger')
 
 
 @view_config(route_name='sample_route', renderer='json')
-def sample(request):
+def sample(dummy_request):
     return {}
 
 
 @view_config(route_name='sample_route_v2', renderer='json')
-def sample_v2(request):
+def sample_v2(dummy_request):
     zipkin_logger.debug({
         'annotations': {'foo': 2},
         'binary_annotations': {'ping': 'pong'},
@@ -28,7 +28,7 @@ def sample_v2(request):
 
 
 @view_config(route_name='sample_route_v2_client', renderer='json')
-def sample_v2_client(request):
+def sample_v2_client(dummy_request):
     zipkin_logger.debug({
         'annotations': {'foo_client': 2},
         'name': 'v2_client',
@@ -43,7 +43,7 @@ def sample_v2_client(request):
 
 
 @view_config(route_name='span_context', renderer='json')
-def span_context(request):
+def span_context(dummy_request):
     # These annotations should go to the server span
     zipkin_logger.debug({
         'annotations': {'server_annotation': 1},
@@ -70,19 +70,19 @@ def span_context(request):
 
 
 @view_config(route_name='sample_route_child_span', renderer='json')
-def sample_child_span(request):
+def sample_child_span(dummy_request):
     return zipkin.create_headers_for_new_span()
 
 
 @view_config(route_name='server_error', renderer='json')
-def server_error(request):
+def server_error(dummy_request):
     response = Response('Server Error!')
     response.status_int = 500
     return response
 
 
 @view_config(route_name='client_error', renderer='json')
-def client_error(request):
+def client_error(dummy_request):
     response = Response('Client Error!')
     response.status_int = 400
     return response

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -2,13 +2,13 @@ import pytest
 
 
 @pytest.fixture
-def default_trace_id_generator(request):
-    return lambda request: '17133d482ba4f605'
+def default_trace_id_generator(dummy_request):
+    return lambda dummy_request: '17133d482ba4f605'
 
 
 @pytest.fixture
-def sampled_trace_id_generator(request):
-    return lambda request: '0' * 16
+def sampled_trace_id_generator(dummy_request):
+    return lambda dummy_request: '0' * 16
 
 
 @pytest.fixture

--- a/tests/acceptance/server_span_test.py
+++ b/tests/acceptance/server_span_test.py
@@ -9,10 +9,9 @@ from tests.acceptance import test_helper
 from pyramid_zipkin.thrift_helper import unsigned_hex_to_signed_int
 
 
-#This test _must_ be the first test in this file
+# This test _must_ be the first test in this file
 def test_zipkin_doesnt_spew_on_first_log(capfd):
     import logging
-    from pyramid_zipkin import zipkin
 
     zipkin_logger = logging.getLogger('pyramid_zipkin.logger')
 

--- a/tests/acceptance/server_span_test.py
+++ b/tests/acceptance/server_span_test.py
@@ -116,8 +116,8 @@ def test_server_extra_annotations_are_included(
 
 @mock.patch('pyramid_zipkin.logging_helper.thrift_obj_in_bytes', autospec=True)
 def test_binary_annotations(thrift_obj, default_trace_id_generator):
-    def set_extra_binary_annotations(request, response):
-        return {'other': request.registry.settings['other_attr']}
+    def set_extra_binary_annotations(dummy_request, response):
+        return {'other': dummy_request.registry.settings['other_attr']}
 
     settings = {
         'zipkin.tracing_percent': 100,

--- a/tests/acceptance/server_span_test.py
+++ b/tests/acceptance/server_span_test.py
@@ -9,23 +9,6 @@ from tests.acceptance import test_helper
 from pyramid_zipkin.thrift_helper import unsigned_hex_to_signed_int
 
 
-# This test _must_ be the first test in this file
-def test_zipkin_doesnt_spew_on_first_log(capfd):
-    import logging
-
-    zipkin_logger = logging.getLogger('pyramid_zipkin.logger')
-
-    zipkin_logger.debug({
-        'annotations': {'foo': 2},
-        'name': 'bar',
-    })
-
-    out, err = capfd.readouterr()
-
-    assert not err
-    assert not out
-
-
 @mock.patch('pyramid_zipkin.logging_helper.thrift_obj_in_bytes', autospec=True)
 def test_sample_server_span_with_100_percent_tracing(
         thrift_obj, default_trace_id_generator, get_span):

--- a/tests/acceptance/server_span_test.py
+++ b/tests/acceptance/server_span_test.py
@@ -9,6 +9,24 @@ from tests.acceptance import test_helper
 from pyramid_zipkin.thrift_helper import unsigned_hex_to_signed_int
 
 
+#This test _must_ be the first test in this file
+def test_zipkin_doesnt_spew_on_first_log(capfd):
+    import logging
+    from pyramid_zipkin import zipkin
+
+    zipkin_logger = logging.getLogger('pyramid_zipkin.logger')
+
+    zipkin_logger.debug({
+        'annotations': {'foo': 2},
+        'name': 'bar',
+    })
+
+    out, err = capfd.readouterr()
+
+    assert not err
+    assert not out
+
+
 @mock.patch('pyramid_zipkin.logging_helper.thrift_obj_in_bytes', autospec=True)
 def test_sample_server_span_with_100_percent_tracing(
         thrift_obj, default_trace_id_generator, get_span):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from pyramid_zipkin import request_helper
 
 
 @pytest.fixture
-def request():
+def dummy_request():
     request = mock.Mock()
     request.registry.settings = {}
     request.headers = {}

--- a/tests/logging_helper_test.py
+++ b/tests/logging_helper_test.py
@@ -27,7 +27,8 @@ def test_zipkin_logging_context(time_mock, mock_logger, context):
             mock_logger.addHandler.assert_called_once_with(context.handler)
             assert context.start_timestamp == 42
         # Make sure the handler and the zipkin attrs are gone
-        mock_logger.removeHandler.assert_called_once_with(context.handler)
+        mock_logger.removeHandler.assert_called_with(context.handler)
+        assert mock_logger.removeHandler.call_count == 2
         assert context.log_spans.call_count == 1
 
 

--- a/tests/logging_helper_test.py
+++ b/tests/logging_helper_test.py
@@ -7,6 +7,23 @@ from pyramid_zipkin.exception import ZipkinError
 from pyramid_zipkin.request_helper import ZipkinAttrs
 
 
+# This test _must_ be the first test in this file
+def test_zipkin_doesnt_spew_on_first_log(capfd):
+    import logging
+
+    zipkin_logger = logging.getLogger('pyramid_zipkin.logger')
+
+    zipkin_logger.debug({
+        'annotations': {'foo': 2},
+        'name': 'bar',
+    })
+
+    out, err = capfd.readouterr()
+
+    assert not err
+    assert not out
+
+
 @pytest.fixture
 def context():
     attr = ZipkinAttrs(None, None, None, None, False)
@@ -239,7 +256,9 @@ def test_log_span_uses_default_stream_name_if_not_provided(thrift_obj, create_sp
         '0000000000000002', '0000000000000001', '00000000000000015',
         'span', 'ann', 'binary_ann', registry
     )
-    transport_handler.assert_called_once_with('zipkin', thrift_obj.return_value)
+    transport_handler.assert_called_once_with(
+        'zipkin', thrift_obj.return_value
+    )
 
 
 @mock.patch('pyramid_zipkin.logging_helper.create_span', autospec=True)

--- a/tests/request_helper_test.py
+++ b/tests/request_helper_test.py
@@ -13,40 +13,40 @@ def test_generate_random_64bit_string(rand):
     assert isinstance(random_string, str)
 
 
-def test_should_not_sample_path_returns_true_if_path_is_blacklisted(request):
-    request.registry.settings = {'zipkin.blacklisted_paths': [r'^/foo/?']}
+def test_should_not_sample_path_returns_true_if_path_is_blacklisted(dummy_request):
+    dummy_request.registry.settings = {'zipkin.blacklisted_paths': [r'^/foo/?']}
     for path in ['/foo', '/foo/1/3', '/foo/bar', '/foobar']:
-        request.path = path
-        assert request_helper.should_not_sample_path(request)
+        dummy_request.path = path
+        assert request_helper.should_not_sample_path(dummy_request)
 
 
-def test_should_not_sample_path_returns_false_if_path_not_blacklisted(request):
-    request.registry.settings = {'zipkin.blacklisted_paths': [r'^/foo/?']}
+def test_should_not_sample_path_returns_false_if_path_not_blacklisted(dummy_request):
+    dummy_request.registry.settings = {'zipkin.blacklisted_paths': [r'^/foo/?']}
     for path in ['/bar', '/bar/foo', '/foe']:
-        request.path = path
-        assert not request_helper.should_not_sample_path(request)
+        dummy_request.path = path
+        assert not request_helper.should_not_sample_path(dummy_request)
 
 
-def test_should_not_sample_route_returns_true_if_route_is_blacklisted(request):
-    request.registry.settings = {'zipkin.blacklisted_routes': ['foo.bar']}
+def test_should_not_sample_route_returns_true_if_route_is_blacklisted(dummy_request):
+    dummy_request.registry.settings = {'zipkin.blacklisted_routes': ['foo.bar']}
     route = mock.Mock()
     route.name = 'foo.bar'
-    request.registry.queryUtility = lambda _: lambda req: {'route': route}
-    assert request_helper.should_not_sample_route(request)
+    dummy_request.registry.queryUtility = lambda _: lambda req: {'route': route}
+    assert request_helper.should_not_sample_route(dummy_request)
 
 
 def test_should_not_sample_route_returns_false_if_route_is_not_blacklisted(
-        request):
-    request.registry.settings = {'zipkin.blacklisted_routes': ['bar']}
+        dummy_request):
+    dummy_request.registry.settings = {'zipkin.blacklisted_routes': ['bar']}
     route = mock.Mock()
     route.name = 'foo'
-    request.registry.queryUtility = lambda _: lambda req: {'route': route}
-    assert not request_helper.should_not_sample_route(request)
+    dummy_request.registry.queryUtility = lambda _: lambda req: {'route': route}
+    assert not request_helper.should_not_sample_route(dummy_request)
 
 
 def test_should_not_sample_route_returns_false_if_blacklisted_list_is_empty(
-        request):
-    assert not request_helper.should_not_sample_route(request)
+        dummy_request):
+    assert not request_helper.should_not_sample_route(dummy_request)
 
 
 def test_should_be_sampled_as_per_zipkin_tracing_percent_retrns_true_for_100():
@@ -61,71 +61,71 @@ def test_should_be_sampled_as_per_zipkin_tracing_percent_returns_false_for_0():
 
 @mock.patch('pyramid_zipkin.request_helper.should_not_sample_path',
             autospec=True)
-def test_is_tracing_returns_false_if_path_should_not_be_sampled(mock, request):
+def test_is_tracing_returns_false_if_path_should_not_be_sampled(mock, dummy_request):
     mock.return_value = True
-    assert not request_helper.is_tracing(request)
+    assert not request_helper.is_tracing(dummy_request)
 
 
 @mock.patch('pyramid_zipkin.request_helper.should_not_sample_route',
             autospec=True)
-def test_is_tracing_return_false_if_route_should_not_be_sampled(mock, request):
+def test_is_tracing_return_false_if_route_should_not_be_sampled(mock, dummy_request):
     mock.return_value = True
-    assert not request_helper.is_tracing(request)
+    assert not request_helper.is_tracing(dummy_request)
 
 
-def test_is_tracing_returns_true_if_sampled_value_in_header_was_true(request):
-    request.headers = {'X-B3-Sampled': '1'}
-    assert request_helper.is_tracing(request)
+def test_is_tracing_returns_true_if_sampled_value_in_header_was_true(dummy_request):
+    dummy_request.headers = {'X-B3-Sampled': '1'}
+    assert request_helper.is_tracing(dummy_request)
 
 
-def test_is_tracing_returns_false_if_sampled_value_in_header_was_fals(request):
-    request.headers = {'X-B3-Sampled': '0'}
-    assert not request_helper.is_tracing(request)
+def test_is_tracing_returns_false_if_sampled_value_in_header_was_fals(dummy_request):
+    dummy_request.headers = {'X-B3-Sampled': '0'}
+    assert not request_helper.is_tracing(dummy_request)
 
 
 @mock.patch(
     'pyramid_zipkin.request_helper.should_sample_as_per_zipkin_tracing_percent',
     autospec=True)
 def test_is_tracing_returns_what_tracing_percent_method_returns_for_rest(
-        mock, request):
-    request.zipkin_trace_id = '42'
-    assert mock.return_value == request_helper.is_tracing(request)
+        mock, dummy_request):
+    dummy_request.zipkin_trace_id = '42'
+    assert mock.return_value == request_helper.is_tracing(dummy_request)
     mock.assert_called_once_with(
         request_helper.DEFAULT_REQUEST_TRACING_PERCENT, '42')
 
 
-def test_get_trace_id_returns_header_value_if_present(request):
-    request.headers = {'X-B3-TraceId': '17133d482ba4f605'}
-    request.registry.settings = {
+def test_get_trace_id_returns_header_value_if_present(dummy_request):
+    dummy_request.headers = {'X-B3-TraceId': '17133d482ba4f605'}
+    dummy_request.registry.settings = {
         'zipkin.trace_id_generator': lambda r: '17133d482ba4f605',
     }
-    assert '17133d482ba4f605' == request_helper.get_trace_id(request)
+    assert '17133d482ba4f605' == request_helper.get_trace_id(dummy_request)
 
 
-def test_get_trace_id_runs_custom_trace_id_generator_if_present(request):
-    request.registry.settings = {
+def test_get_trace_id_runs_custom_trace_id_generator_if_present(dummy_request):
+    dummy_request.registry.settings = {
         'zipkin.trace_id_generator': lambda r: '27133d482ba4f605',
     }
-    assert '27133d482ba4f605' == request_helper.get_trace_id(request)
+    assert '27133d482ba4f605' == request_helper.get_trace_id(dummy_request)
 
 
 @mock.patch('pyramid_zipkin.request_helper.generate_random_64bit_string',
             autospec=True)
-def test_get_trace_id_returns_some_random_id_by_default(compat, request):
+def test_get_trace_id_returns_some_random_id_by_default(compat, dummy_request):
     compat.return_value = '37133d482ba4f605'
-    assert '37133d482ba4f605' == request_helper.get_trace_id(request)
+    assert '37133d482ba4f605' == request_helper.get_trace_id(dummy_request)
 
 
-def test_get_trace_id_works_with_old_style_hex_string(request):
-    request.headers = {'X-B3-TraceId': '-0x3ab5151d76fb85e1'}
-    assert 'c54aeae289047a1f' == request_helper.get_trace_id(request)
+def test_get_trace_id_works_with_old_style_hex_string(dummy_request):
+    dummy_request.headers = {'X-B3-TraceId': '-0x3ab5151d76fb85e1'}
+    assert 'c54aeae289047a1f' == request_helper.get_trace_id(dummy_request)
 
 
 @mock.patch('pyramid_zipkin.request_helper.is_tracing', autospec=True)
-def test_create_sampled_zipkin_attr_creates_ZipkinAttr_object(mock, request):
+def test_create_sampled_zipkin_attr_creates_ZipkinAttr_object(mock, dummy_request):
     mock.return_value = 'bla'
-    request.zipkin_trace_id = '12'
-    request.headers = {
+    dummy_request.zipkin_trace_id = '12'
+    dummy_request.headers = {
         'X-B3-TraceId': '12',
         'X-B3-SpanId': '23',
         'X-B3-ParentSpanId': '34',
@@ -134,7 +134,7 @@ def test_create_sampled_zipkin_attr_creates_ZipkinAttr_object(mock, request):
     zipkin_attr = request_helper.ZipkinAttrs(
         trace_id='12', span_id='23', parent_span_id='34', flags='45',
         is_sampled='bla')
-    assert zipkin_attr == request_helper.create_zipkin_attr(request)
+    assert zipkin_attr == request_helper.create_zipkin_attr(dummy_request)
 
 
 def test_signed_hex_to_unsigned_hex():

--- a/tests/request_helper_test.py
+++ b/tests/request_helper_test.py
@@ -14,96 +14,102 @@ def test_generate_random_64bit_string(rand):
 
 
 def test_should_not_sample_path_returns_true_if_path_is_blacklisted(
-        dummy_request):
-    dummy_request.registry.settings = {
-        'zipkin.blacklisted_paths': [r'^/foo/?']}
+    dummy_request
+):
+    dummy_request.registry.settings = {'zipkin.blacklisted_paths': [r'^/foo/?']}
     for path in ['/foo', '/foo/1/3', '/foo/bar', '/foobar']:
         dummy_request.path = path
         assert request_helper.should_not_sample_path(dummy_request)
 
 
 def test_should_not_sample_path_returns_false_if_path_not_blacklisted(
-        dummy_request):
-    dummy_request.registry.settings = {
-        'zipkin.blacklisted_paths': [r'^/foo/?']}
+    dummy_request
+):
+    dummy_request.registry.settings = {'zipkin.blacklisted_paths': [r'^/foo/?']}
     for path in ['/bar', '/bar/foo', '/foe']:
         dummy_request.path = path
         assert not request_helper.should_not_sample_path(dummy_request)
 
 
 def test_should_not_sample_route_returns_true_if_route_is_blacklisted(
-        dummy_request):
-    dummy_request.registry.settings = {
-        'zipkin.blacklisted_routes': ['foo.bar']}
+    dummy_request
+):
+    dummy_request.registry.settings = {'zipkin.blacklisted_routes': ['foo.bar']}
     route = mock.Mock()
     route.name = 'foo.bar'
-    dummy_request.registry.queryUtility = lambda _: lambda req: {
-        'route': route}
+    dummy_request.registry.queryUtility = lambda _: lambda req: {'route': route}
     assert request_helper.should_not_sample_route(dummy_request)
 
 
 def test_should_not_sample_route_returns_false_if_route_is_not_blacklisted(
-        dummy_request):
+    dummy_request
+):
     dummy_request.registry.settings = {'zipkin.blacklisted_routes': ['bar']}
     route = mock.Mock()
     route.name = 'foo'
-    dummy_request.registry.queryUtility = lambda _: lambda req: {
-        'route': route}
+    dummy_request.registry.queryUtility = lambda _: lambda req: {'route': route}
     assert not request_helper.should_not_sample_route(dummy_request)
 
 
 def test_should_not_sample_route_returns_false_if_blacklisted_list_is_empty(
-        dummy_request):
+    dummy_request
+):
     assert not request_helper.should_not_sample_route(dummy_request)
 
 
 def test_should_be_sampled_as_per_zipkin_tracing_percent_retrns_true_for_100():
-    assert request_helper.should_sample_as_per_zipkin_tracing_percent(
-        100.0, '42')
+    assert request_helper.should_sample_as_per_zipkin_tracing_percent(100.0, '42')
 
 
 def test_should_be_sampled_as_per_zipkin_tracing_percent_returns_false_for_0():
-    assert not request_helper.should_sample_as_per_zipkin_tracing_percent(
-        0, '42')
+    assert not request_helper.should_sample_as_per_zipkin_tracing_percent(0, '42')
 
 
-@mock.patch('pyramid_zipkin.request_helper.should_not_sample_path',
-            autospec=True)
+@mock.patch('pyramid_zipkin.request_helper.should_not_sample_path', autospec=True)
 def test_is_tracing_returns_false_if_path_should_not_be_sampled(
-        mock, dummy_request):
+    mock, dummy_request
+):
     mock.return_value = True
     assert not request_helper.is_tracing(dummy_request)
 
 
-@mock.patch('pyramid_zipkin.request_helper.should_not_sample_route',
-            autospec=True)
+@mock.patch(
+    'pyramid_zipkin.request_helper.should_not_sample_route',
+    autospec=True
+)
 def test_is_tracing_return_false_if_route_should_not_be_sampled(
-        mock, dummy_request):
+    mock, dummy_request
+):
     mock.return_value = True
     assert not request_helper.is_tracing(dummy_request)
 
 
 def test_is_tracing_returns_true_if_sampled_value_in_header_was_true(
-        dummy_request):
+    dummy_request
+):
     dummy_request.headers = {'X-B3-Sampled': '1'}
     assert request_helper.is_tracing(dummy_request)
 
 
 def test_is_tracing_returns_false_if_sampled_value_in_header_was_fals(
-        dummy_request):
+    dummy_request
+):
     dummy_request.headers = {'X-B3-Sampled': '0'}
     assert not request_helper.is_tracing(dummy_request)
 
 
 @mock.patch(
     'pyramid_zipkin.request_helper.should_sample_as_per_zipkin_tracing_percent',
-    autospec=True)
+    autospec=True
+)
 def test_is_tracing_returns_what_tracing_percent_method_returns_for_rest(
-        mock, dummy_request):
+    mock, dummy_request
+):
     dummy_request.zipkin_trace_id = '42'
     assert mock.return_value == request_helper.is_tracing(dummy_request)
     mock.assert_called_once_with(
-        request_helper.DEFAULT_REQUEST_TRACING_PERCENT, '42')
+        request_helper.DEFAULT_REQUEST_TRACING_PERCENT, '42'
+    )
 
 
 def test_get_trace_id_returns_header_value_if_present(dummy_request):
@@ -121,8 +127,10 @@ def test_get_trace_id_runs_custom_trace_id_generator_if_present(dummy_request):
     assert '27133d482ba4f605' == request_helper.get_trace_id(dummy_request)
 
 
-@mock.patch('pyramid_zipkin.request_helper.generate_random_64bit_string',
-            autospec=True)
+@mock.patch(
+    'pyramid_zipkin.request_helper.generate_random_64bit_string',
+    autospec=True
+)
 def test_get_trace_id_returns_some_random_id_by_default(compat, dummy_request):
     compat.return_value = '37133d482ba4f605'
     assert '37133d482ba4f605' == request_helper.get_trace_id(dummy_request)
@@ -135,7 +143,8 @@ def test_get_trace_id_works_with_old_style_hex_string(dummy_request):
 
 @mock.patch('pyramid_zipkin.request_helper.is_tracing', autospec=True)
 def test_create_sampled_zipkin_attr_creates_ZipkinAttr_object(
-        mock, dummy_request):
+    mock, dummy_request
+):
     mock.return_value = 'bla'
     dummy_request.zipkin_trace_id = '12'
     dummy_request.headers = {
@@ -145,13 +154,21 @@ def test_create_sampled_zipkin_attr_creates_ZipkinAttr_object(
         'X-B3-Flags': '45',
     }
     zipkin_attr = request_helper.ZipkinAttrs(
-        trace_id='12', span_id='23', parent_span_id='34', flags='45',
-        is_sampled='bla')
+        trace_id='12',
+        span_id='23',
+        parent_span_id='34',
+        flags='45',
+        is_sampled='bla'
+    )
     assert zipkin_attr == request_helper.create_zipkin_attr(dummy_request)
 
 
 def test_signed_hex_to_unsigned_hex():
-    assert (request_helper._signed_hex_to_unsigned_hex('0xd68adf75f4cfd13') ==
-            'd68adf75f4cfd13')
-    assert (request_helper._signed_hex_to_unsigned_hex('-0x3ab5151d76fb85e1') ==
-            'c54aeae289047a1f')
+    assert (
+        request_helper._signed_hex_to_unsigned_hex('0xd68adf75f4cfd13') ==
+        'd68adf75f4cfd13'
+    )
+    assert (
+        request_helper._signed_hex_to_unsigned_hex('-0x3ab5151d76fb85e1') ==
+        'c54aeae289047a1f'
+    )

--- a/tests/request_helper_test.py
+++ b/tests/request_helper_test.py
@@ -13,25 +13,32 @@ def test_generate_random_64bit_string(rand):
     assert isinstance(random_string, str)
 
 
-def test_should_not_sample_path_returns_true_if_path_is_blacklisted(dummy_request):
-    dummy_request.registry.settings = {'zipkin.blacklisted_paths': [r'^/foo/?']}
+def test_should_not_sample_path_returns_true_if_path_is_blacklisted(
+        dummy_request):
+    dummy_request.registry.settings = {
+        'zipkin.blacklisted_paths': [r'^/foo/?']}
     for path in ['/foo', '/foo/1/3', '/foo/bar', '/foobar']:
         dummy_request.path = path
         assert request_helper.should_not_sample_path(dummy_request)
 
 
-def test_should_not_sample_path_returns_false_if_path_not_blacklisted(dummy_request):
-    dummy_request.registry.settings = {'zipkin.blacklisted_paths': [r'^/foo/?']}
+def test_should_not_sample_path_returns_false_if_path_not_blacklisted(
+        dummy_request):
+    dummy_request.registry.settings = {
+        'zipkin.blacklisted_paths': [r'^/foo/?']}
     for path in ['/bar', '/bar/foo', '/foe']:
         dummy_request.path = path
         assert not request_helper.should_not_sample_path(dummy_request)
 
 
-def test_should_not_sample_route_returns_true_if_route_is_blacklisted(dummy_request):
-    dummy_request.registry.settings = {'zipkin.blacklisted_routes': ['foo.bar']}
+def test_should_not_sample_route_returns_true_if_route_is_blacklisted(
+        dummy_request):
+    dummy_request.registry.settings = {
+        'zipkin.blacklisted_routes': ['foo.bar']}
     route = mock.Mock()
     route.name = 'foo.bar'
-    dummy_request.registry.queryUtility = lambda _: lambda req: {'route': route}
+    dummy_request.registry.queryUtility = lambda _: lambda req: {
+        'route': route}
     assert request_helper.should_not_sample_route(dummy_request)
 
 
@@ -40,7 +47,8 @@ def test_should_not_sample_route_returns_false_if_route_is_not_blacklisted(
     dummy_request.registry.settings = {'zipkin.blacklisted_routes': ['bar']}
     route = mock.Mock()
     route.name = 'foo'
-    dummy_request.registry.queryUtility = lambda _: lambda req: {'route': route}
+    dummy_request.registry.queryUtility = lambda _: lambda req: {
+        'route': route}
     assert not request_helper.should_not_sample_route(dummy_request)
 
 
@@ -61,24 +69,28 @@ def test_should_be_sampled_as_per_zipkin_tracing_percent_returns_false_for_0():
 
 @mock.patch('pyramid_zipkin.request_helper.should_not_sample_path',
             autospec=True)
-def test_is_tracing_returns_false_if_path_should_not_be_sampled(mock, dummy_request):
+def test_is_tracing_returns_false_if_path_should_not_be_sampled(
+        mock, dummy_request):
     mock.return_value = True
     assert not request_helper.is_tracing(dummy_request)
 
 
 @mock.patch('pyramid_zipkin.request_helper.should_not_sample_route',
             autospec=True)
-def test_is_tracing_return_false_if_route_should_not_be_sampled(mock, dummy_request):
+def test_is_tracing_return_false_if_route_should_not_be_sampled(
+        mock, dummy_request):
     mock.return_value = True
     assert not request_helper.is_tracing(dummy_request)
 
 
-def test_is_tracing_returns_true_if_sampled_value_in_header_was_true(dummy_request):
+def test_is_tracing_returns_true_if_sampled_value_in_header_was_true(
+        dummy_request):
     dummy_request.headers = {'X-B3-Sampled': '1'}
     assert request_helper.is_tracing(dummy_request)
 
 
-def test_is_tracing_returns_false_if_sampled_value_in_header_was_fals(dummy_request):
+def test_is_tracing_returns_false_if_sampled_value_in_header_was_fals(
+        dummy_request):
     dummy_request.headers = {'X-B3-Sampled': '0'}
     assert not request_helper.is_tracing(dummy_request)
 
@@ -122,7 +134,8 @@ def test_get_trace_id_works_with_old_style_hex_string(dummy_request):
 
 
 @mock.patch('pyramid_zipkin.request_helper.is_tracing', autospec=True)
-def test_create_sampled_zipkin_attr_creates_ZipkinAttr_object(mock, dummy_request):
+def test_create_sampled_zipkin_attr_creates_ZipkinAttr_object(
+        mock, dummy_request):
     mock.return_value = 'bla'
     dummy_request.zipkin_trace_id = '12'
     dummy_request.headers = {
@@ -130,7 +143,7 @@ def test_create_sampled_zipkin_attr_creates_ZipkinAttr_object(mock, dummy_reques
         'X-B3-SpanId': '23',
         'X-B3-ParentSpanId': '34',
         'X-B3-Flags': '45',
-        }
+    }
     zipkin_attr = request_helper.ZipkinAttrs(
         trace_id='12', span_id='23', parent_span_id='34', flags='45',
         is_sampled='bla')

--- a/tests/thrift_helper_test.py
+++ b/tests/thrift_helper_test.py
@@ -24,11 +24,11 @@ def test_create_span(Span):
 
 
 @mock.patch('socket.gethostbyname', autospec=True)
-def test_create_endpoint_creates_correct_endpoint(gethostbyname, request):
+def test_create_endpoint_creates_correct_endpoint(gethostbyname, dummy_request):
     gethostbyname.return_value = '0.0.0.0'
-    request.registry.settings = {'service_name': 'foo'}
-    request.server_port = 8080
-    endpoint = thrift_helper.create_endpoint(request)
+    dummy_request.registry.settings = {'service_name': 'foo'}
+    dummy_request.server_port = 8080
+    endpoint = thrift_helper.create_endpoint(dummy_request)
     assert endpoint.service_name == 'foo'
     assert endpoint.port == 8080
     # An IP address of 0.0.0.0 unpacks to just 0
@@ -36,11 +36,11 @@ def test_create_endpoint_creates_correct_endpoint(gethostbyname, request):
 
 
 @mock.patch('socket.gethostbyname', autospec=True)
-def test_copy_endpoint_with_new_service_name(gethostbyname, request):
+def test_copy_endpoint_with_new_service_name(gethostbyname, dummy_request):
     gethostbyname.return_value = '0.0.0.0'
-    request.registry.settings = {'service_name': 'foo'}
-    request.server_port = 8080
-    endpoint = thrift_helper.create_endpoint(request)
+    dummy_request.registry.settings = {'service_name': 'foo'}
+    dummy_request.server_port = 8080
+    endpoint = thrift_helper.create_endpoint(dummy_request)
     new_endpoint = thrift_helper.copy_endpoint_with_new_service_name(
             endpoint, 'blargh')
     assert new_endpoint.port == 8080


### PR DESCRIPTION
If a user's application does not configure logging, 'No handlers could be found for logger "pyramid_zipkin.logger"' will be printed out. Based on the logging [cookbook](https://docs.python.org/3/howto/logging.html#library-config), we can add in a NullHandler to dump the logs into the eternal void.