### PR TITLE
Fix pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,5 +11,6 @@
     -   id: name-tests-test
         exclude: tests/acceptance/test_helper.py
     -   id: flake8
+        args: ['--max-line-length=82']
         exclude: docs/source/conf.py
     -   id: requirements-txt-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: 3472f2b3ce972de7b440a387a81c76f67d5539cd
+    sha: v0.5.1
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@
     -   id: check-yaml
     -   id: debug-statements
     -   id: name-tests-test
+        exclude: tests/acceptance/test_helper.py
     -   id: flake8
         exclude: docs/source/conf.py
     -   id: requirements-txt-fixer

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -199,4 +199,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-

--- a/pyramid_zipkin/logging_helper.py
+++ b/pyramid_zipkin/logging_helper.py
@@ -26,6 +26,7 @@ class ZipkinLoggingContext(object):
     :type log_handler: :class:`pyramid_zipkin.logging_helper.ZipkinLoggerHandler`
     :param request: active pyramid request object
     """
+
     def __init__(self, zipkin_attrs, thrift_endpoint, log_handler, request):
         self.zipkin_attrs = zipkin_attrs
         self.thrift_endpoint = thrift_endpoint
@@ -88,7 +89,8 @@ class ZipkinLoggingContext(object):
                 annotations = span['annotations']
                 annotations.update(annotations_by_span_id[span_id])
                 binary_annotations = span['binary_annotations']
-                binary_annotations.update(binary_annotations_by_span_id[span_id])
+                binary_annotations.update(
+                    binary_annotations_by_span_id[span_id])
                 # Create serializable thrift objects of annotations
                 thrift_annotations = annotation_list_builder(
                     annotations, endpoint
@@ -108,7 +110,8 @@ class ZipkinLoggingContext(object):
                 )
 
             # Collect extra annotations for server span, then log it.
-            extra_annotations = annotations_by_span_id[self.zipkin_attrs.span_id]
+            extra_annotations = annotations_by_span_id[
+                self.zipkin_attrs.span_id]
             extra_binary_annotations = binary_annotations_by_span_id[
                 self.zipkin_attrs.span_id
             ]

--- a/pyramid_zipkin/request_helper.py
+++ b/pyramid_zipkin/request_helper.py
@@ -45,7 +45,8 @@ def get_trace_id(request):
     if 'X-B3-TraceId' in request.headers:
         trace_id = request.headers['X-B3-TraceId']
     elif 'zipkin.trace_id_generator' in request.registry.settings:
-        trace_id = request.registry.settings['zipkin.trace_id_generator'](request)
+        trace_id = request.registry.settings[
+            'zipkin.trace_id_generator'](request)
     else:
         trace_id = generate_random_64bit_string()
 
@@ -154,7 +155,8 @@ def create_zipkin_attr(request):
 
     trace_id = request.zipkin_trace_id
     is_sampled = is_tracing(request)
-    span_id = request.headers.get('X-B3-SpanId', generate_random_64bit_string())
+    span_id = request.headers.get(
+        'X-B3-SpanId', generate_random_64bit_string())
     parent_span_id = request.headers.get('X-B3-ParentSpanId', None)
     flags = request.headers.get('X-B3-Flags', '0')
     return ZipkinAttrs(

--- a/pyramid_zipkin/zipkin.py
+++ b/pyramid_zipkin/zipkin.py
@@ -55,7 +55,7 @@ def zipkin_tween(handler, registry):
                 response = handler(request)
                 context.response_status_code = response.status_code
                 context.binary_annotations_dict = get_binary_annotations(
-                        request, response)
+                    request, response)
 
                 return response
         finally:
@@ -102,6 +102,7 @@ class SpanContext(object):
     context. Outside this context, the proper logging handlers will
     not be set up.
     """
+
     def __init__(
         self, service_name, span_name='span',
         annotations=None, binary_annotations=None,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal = True
+
+[pep8]
+ignore = E265,E309,E501

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ setup(
     url="https://github.com/Yelp/pyramid_zipkin",
     description='Zipkin distributed tracing system support library for pyramid.',
     packages=find_packages(exclude=('tests*', 'testing*', 'tools*')),
-    package_data = { '': [ '*.thrift' ] },
-    install_requires = [
+    package_data={'': ['*.thrift']},
+    install_requires=[
         'pyramid',
         'six',
         'thriftpy',

--- a/tests/acceptance/span_context_test.py
+++ b/tests/acceptance/span_context_test.py
@@ -106,8 +106,10 @@ def test_span_context(
     assert_extra_annotations(server_span, {'server_annotation': 1000000})
     assert_extra_binary_annotations(server_span, {'server': 'true'})
     assert_extra_annotations(child_span, {'child_annotation': 1000000})
-    assert_extra_binary_annotations(child_span, {'foo': 'bar', 'child': 'true'})
-    assert_extra_annotations(grandchild_span, {'grandchild_annotation': 1000000})
+    assert_extra_binary_annotations(
+        child_span, {'foo': 'bar', 'child': 'true'})
+    assert_extra_annotations(
+        grandchild_span, {'grandchild_annotation': 1000000})
     assert_extra_binary_annotations(grandchild_span, {'grandchild': 'true'})
 
     # For the span produced by SpanContext, assert cs==sr and ss==cr

--- a/tests/logging_helper_test.py
+++ b/tests/logging_helper_test.py
@@ -238,7 +238,8 @@ def test_log_span_uses_default_stream_name_if_not_provided(thrift_obj, create_sp
         '0000000000000002', '0000000000000001', '00000000000000015',
         'span', 'ann', 'binary_ann', registry
     )
-    transport_handler.assert_called_once_with('zipkin', thrift_obj.return_value)
+    transport_handler.assert_called_once_with(
+        'zipkin', thrift_obj.return_value)
 
 
 @mock.patch('pyramid_zipkin.logging_helper.create_span', autospec=True)

--- a/tests/request_helper_test.py
+++ b/tests/request_helper_test.py
@@ -130,7 +130,7 @@ def test_create_sampled_zipkin_attr_creates_ZipkinAttr_object(mock, request):
         'X-B3-SpanId': '23',
         'X-B3-ParentSpanId': '34',
         'X-B3-Flags': '45',
-        }
+    }
     zipkin_attr = request_helper.ZipkinAttrs(
         trace_id='12', span_id='23', parent_span_id='34', flags='45',
         is_sampled='bla')

--- a/tests/thrift_helper_test.py
+++ b/tests/thrift_helper_test.py
@@ -42,7 +42,7 @@ def test_copy_endpoint_with_new_service_name(gethostbyname, request):
     request.server_port = 8080
     endpoint = thrift_helper.create_endpoint(request)
     new_endpoint = thrift_helper.copy_endpoint_with_new_service_name(
-            endpoint, 'blargh')
+        endpoint, 'blargh')
     assert new_endpoint.port == 8080
     assert new_endpoint.service_name == 'blargh'
     # An IP address of 0.0.0.0 unpacks to just 0

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -69,7 +69,7 @@ def test_create_headers_for_new_span_returns_header_if_active_request(
         'X-B3-ParentSpanId': '37133d482ba4f605',
         'X-B3-Flags': '0',
         'X-B3-Sampled': '1',
-        }
+    }
     assert expected == zipkin.create_headers_for_new_span()
 
 


### PR DESCRIPTION
This fixes the main issue in #46 by fixing the pre-commit version and letting the pre-commit hooks do their magic.

tests/acceptance/test_helper.py fails the "test files must end in _test.py" pre-commit hook so I excluded it for now. I think this is a legitimate complaint by pre-commit, so we either should relax that constraint (remove the pre-commit hook) or better yet move it into a utils/ or helpers/ directory and exclude that instead of an individual file in the tests directory.