### PR TITLE
remove duplicate line in pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,4 +13,5 @@
     -   id: flake8
         args: ['--max-line-length=82']
         exclude: docs/source/conf.py
+        args: ['--max-line-length=82']
     -   id: requirements-txt-fixer


### PR DESCRIPTION
The last merge added a duplicate line in the .pre-commit-config. remove it