### PR TITLE
Add @zipkin_span decorator

### DIFF
--- a/pyramid_zipkin/zipkin.py
+++ b/pyramid_zipkin/zipkin.py
@@ -199,3 +199,38 @@ class SpanContext(object):
             binary_annotations=self.binary_annotations,
             span_id=self.span_id,
         )
+
+
+def zipkin_span(
+    service_name,
+    span_name,
+    binary_annotations=None,
+):
+    """Decorator utility for logging a function as a Zipkin span.
+    Note that the decorator doesn't accept timestamp annotations.
+    Any timestamps included in the decorator would likely be way off,
+    as they wouldn't be able to be dependent on request time.
+
+    Usage:
+
+    @zipkin_span('my_service', 'my_span_name')
+    def my_funky_function(a, b):
+        return a + b
+
+    :param service_name: Name of the "service" for the to-be-logged span
+    :type service_name: string
+    :param span_name: Name of the span to be logged.
+    :type span_name: string
+    :param binary_annotations: Additional span binary annotations
+    :type binary_annotations: dict of str -> str
+    """
+    def outer(func):
+        def inner(*args, **kwargs):
+            with SpanContext(
+                service_name=service_name,
+                span_name=span_name,
+                binary_annotations=binary_annotations,
+            ):
+                return func(*args, **kwargs)
+        return inner
+    return outer

--- a/pyramid_zipkin/zipkin.py
+++ b/pyramid_zipkin/zipkin.py
@@ -203,14 +203,10 @@ class SpanContext(object):
 
 def zipkin_span(
     service_name,
-    span_name,
+    span_name=None,
     binary_annotations=None,
 ):
     """Decorator utility for logging a function as a Zipkin span.
-    Note that the decorator doesn't accept timestamp annotations.
-    Any timestamps included in the decorator would likely be way off,
-    as they wouldn't be able to be dependent on request time.
-
     Usage:
 
     @zipkin_span('my_service', 'my_span_name')
@@ -219,7 +215,7 @@ def zipkin_span(
 
     :param service_name: Name of the "service" for the to-be-logged span
     :type service_name: string
-    :param span_name: Name of the span to be logged.
+    :param span_name: Name of the span to be logged. Defaults to func.__name__
     :type span_name: string
     :param binary_annotations: Additional span binary annotations
     :type binary_annotations: dict of str -> str
@@ -228,7 +224,7 @@ def zipkin_span(
         def inner(*args, **kwargs):
             with SpanContext(
                 service_name=service_name,
-                span_name=span_name,
+                span_name=span_name or func.__name__,
                 binary_annotations=binary_annotations,
             ):
                 return func(*args, **kwargs)

--- a/tests/acceptance/app/__init__.py
+++ b/tests/acceptance/app/__init__.py
@@ -69,6 +69,16 @@ def span_context(dummy_request):
     return {}
 
 
+@view_config(route_name='decorator_context', renderer='json')
+def decorator_context(dummy_request):
+
+    @zipkin.zipkin_span('my_service', 'my_span', binary_annotations={'a': '1'})
+    def some_function(a, b):
+        return str(a + b)
+
+    return {'result': some_function(1, 2)}
+
+
 @view_config(route_name='sample_route_child_span', renderer='json')
 def sample_child_span(dummy_request):
     return zipkin.create_headers_for_new_span()
@@ -100,6 +110,7 @@ def main(global_config, **settings):
     config.add_route('sample_route_v2_client', '/sample_v2_client')
     config.add_route('sample_route_child_span', '/sample_child_span')
     config.add_route('span_context', '/span_context')
+    config.add_route('decorator_context', '/decorator_context')
 
     config.add_route('server_error', '/server_error')
     config.add_route('client_error', '/client_error')

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -188,3 +188,24 @@ def test_span_context(
         'binary_annotations': {'foo': 'bar'},
     }
     assert client_span == expected_client_span
+
+
+@mock.patch('pyramid_zipkin.zipkin.SpanContext', autospec=True)
+def test_decorator(mock_span_context):
+
+    service_name = 'my_service'
+    span_name = 'my_span'
+    binary_annotations = {'a': '1'}
+
+    @zipkin.zipkin_span(service_name, span_name, binary_annotations)
+    def some_function(a, b):
+        return a + b
+
+    assert some_function(1, 2) == 3
+
+    expected_call = mock.call(
+        service_name=service_name,
+        span_name=span_name,
+        binary_annotations=binary_annotations,
+    )
+    assert expected_call == mock_span_context.call_args

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -209,3 +209,22 @@ def test_decorator(mock_span_context):
         binary_annotations=binary_annotations,
     )
     assert expected_call == mock_span_context.call_args
+
+
+@mock.patch('pyramid_zipkin.zipkin.SpanContext', autospec=True)
+def test_decorator_default_span_name(mock_span_context):
+
+    service_name = 'my_service'
+
+    @zipkin.zipkin_span(service_name)
+    def some_function(a, b):
+        return a + b
+
+    assert some_function(1, 2) == 3
+
+    expected_call = mock.call(
+        service_name=service_name,
+        span_name='some_function',
+        binary_annotations=None,
+    )
+    assert expected_call == mock_span_context.call_args


### PR DESCRIPTION
Will log the wrapped function as its own Zipkin span. Tested in yelp-main.