### PR TITLE
Use py27 for flake8 / docs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,13 @@ commands =
     coverage report -m --show-missing --fail-under 100
 
 [testenv:flake8]
+basepython = /usr/bin/python2.7
 deps = flake8
 commands =
     flake8 pyramid_zipkin tests
 
 [testenv:docs]
+basepython = /usr/bin/python2.7
 deps = {[testenv]deps}
     sphinx
 changedir = docs


### PR DESCRIPTION
This fixes our internal jenkins build (which has been timing out since flake8 dropped py27 support)

(I'd suggest dropping py26 anyway)