### PR TITLE
Drop py26 and add py35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 language: python
+python: 3.5
 env:
-- TOX_ENV=py26
-- TOX_ENV=py27
-- TOX_ENV=py33
-- TOX_ENV=py34
-- TOX_ENV=docs
-- TOX_ENV=flake8
-install:
-- "pip install --use-mirrors tox coveralls"
-script:
-- tox -e $TOX_ENV
-after_success:
-- coveralls
+- TOXENV=py27
+- TOXENV=py34
+- TOXENV=py35
+- TOXENV=docs
+- TOXENV=flake8
+install: pip install tox coveralls
+script: tox
+after_success: coveralls
 sudo: false

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,8 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, flake8
+envlist = py27, py34, py35, flake8
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
I'll fix our internal build with some sed (we've done this in other places) since we only have tox>2 as a binary `tox2`

Resolves #38.
Resolves #48.