### PR TITLE
default service_name to 'unknown'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+0.12.2 (2016-07-15)
+-------------------
+- make "service_name" default to "unknown" when not found in registry
+
 0.12.1 (2016-07-08)
 -------------------
 - Add @zipkin_span decorator for logging functions as spans

--- a/pyramid_zipkin/thrift_helper.py
+++ b/pyramid_zipkin/thrift_helper.py
@@ -50,7 +50,7 @@ def create_endpoint(request):
     :param request: pyramid request object
     :returns: zipkin endpoint object
     """
-    service_name = request.registry.settings['service_name']
+    service_name = request.registry.settings.get('service_name', 'unknown')
     host = socket.gethostbyname(socket.gethostname())
     port = request.server_port
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = "0.12.1"
+__version__ = "0.12.2"
 
 setup(
     name='pyramid_zipkin',

--- a/tests/thrift_helper_test.py
+++ b/tests/thrift_helper_test.py
@@ -36,6 +36,17 @@ def test_create_endpoint_creates_correct_endpoint(gethostbyname, dummy_request):
 
 
 @mock.patch('socket.gethostbyname', autospec=True)
+def test_create_endpoint_defaults_service_name(gethostbyname, dummy_request):
+    gethostbyname.return_value = '0.0.0.0'
+    dummy_request.server_port = 8080
+    endpoint = thrift_helper.create_endpoint(dummy_request)
+    assert endpoint.service_name == 'unknown'
+    assert endpoint.port == 8080
+    # An IP address of 0.0.0.0 unpacks to just 0
+    assert endpoint.ipv4 == 0
+
+
+@mock.patch('socket.gethostbyname', autospec=True)
 def test_copy_endpoint_with_new_service_name(gethostbyname, dummy_request):
     gethostbyname.return_value = '0.0.0.0'
     dummy_request.registry.settings = {'service_name': 'foo'}


### PR DESCRIPTION
service_name is required, but there is no reason why we should die if it isn't set