### PR TITLE
Fix coverage command invocation and bump package to v0.12.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+0.12.3 (2016-07-27)
+-------------------
+- Fix coverage command invocation to be compatible with coverage v4.2
+
 0.12.2 (2016-07-15)
 -------------------
 - make "service_name" default to "unknown" when not found in registry

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = "0.12.2"
+__version__ = "0.12.3"
 
 setup(
     name='pyramid_zipkin',

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps = -rrequirements-dev.txt
 commands =
     coverage erase
     coverage run --source=pyramid_zipkin/ -m pytest -vv {posargs:tests}
-    coverage combine
+    coverage combine --append
     coverage report -m --show-missing --fail-under 100
 
 [testenv:flake8]


### PR DESCRIPTION
Same fix as https://github.com/Yelp/bravado-core/commit/0cc4b73f95c9be6e350e442e9552dd7d22cdfce7