### PR TITLE
Tolerates reads of 128 bit X-B3-TraceId

### DIFF
--- a/pyramid_zipkin/request_helper.py
+++ b/pyramid_zipkin/request_helper.py
@@ -19,7 +19,9 @@ def get_trace_id(request):
     :returns: a 64-bit hex string
     """
     if 'X-B3-TraceId' in request.headers:
-        trace_id = request.headers['X-B3-TraceId']
+        # Tolerates 128 bit X-B3-TraceId by reading the right-most 16 hex
+        # characters (as opposed to overflowing a U64 and starting a new trace).
+        trace_id = request.headers['X-B3-TraceId'][-16:]
     elif 'zipkin.trace_id_generator' in request.registry.settings:
         trace_id = request.registry.settings[
             'zipkin.trace_id_generator'](request)

--- a/tests/request_helper_test.py
+++ b/tests/request_helper_test.py
@@ -103,11 +103,21 @@ def test_is_tracing_returns_what_tracing_percent_method_returns_for_rest(
 
 
 def test_get_trace_id_returns_header_value_if_present(dummy_request):
-    dummy_request.headers = {'X-B3-TraceId': '17133d482ba4f605'}
+    dummy_request.headers = {'X-B3-TraceId': '48485a3953bb6124'}
     dummy_request.registry.settings = {
         'zipkin.trace_id_generator': lambda r: '17133d482ba4f605',
     }
-    assert '17133d482ba4f605' == request_helper.get_trace_id(dummy_request)
+    assert '48485a3953bb6124' == request_helper.get_trace_id(dummy_request)
+
+
+def test_get_trace_id_returns_header_value_if_present_128_bit(dummy_request):
+    # When someone passes a 128-bit trace id, it ends up as 32 hex characters.
+    # We choose the right-most 16 characters (corresponding to the lowest 64 bits)
+    dummy_request.headers = {'X-B3-TraceId': '463ac35c9f6413ad48485a3953bb6124'}
+    dummy_request.registry.settings = {
+        'zipkin.trace_id_generator': lambda r: '17133d482ba4f605',
+    }
+    assert '48485a3953bb6124' == request_helper.get_trace_id(dummy_request)
 
 
 def test_get_trace_id_runs_custom_trace_id_generator_if_present(dummy_request):


### PR DESCRIPTION
The first step of transitioning to 128bit `X-B3-TraceId` is tolerantly reading 32 character long ids by throwing away the high bits (any characters left of 16 characters). This allows the tracing system to more flexibly introduce 128bit trace id support in the future.

Ex. when `X-B3-TraceId: 463ac35c9f6413ad48485a3953bb6124` is received, parse the lower 64 bits (right most 16 characters ex48485a3953bb6124) as the trace id.

See https://github.com/openzipkin/b3-propagation/issues/6