### PR TITLE
[#66] adds pyramid registry checks for is_tracing and create_zipkin_attr

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+0.16.1 (2016-10-14)
+-------------------
+- support for configuring custom versions of create_zipkin_attr and is_tracing
+  through the pyramid registry.
+
 0.16.0 (2016-10-06)
 -------------------
 - Fix sample rate bug and make sampling be random and not depend on request id.

--- a/docs/source/configuring_zipkin.rst
+++ b/docs/source/configuring_zipkin.rst
@@ -110,6 +110,25 @@ zipkin.trace_id_generator
     id deterministic).
 
 
+zipkin.create_zipkin_attr
+~~~~~~~~~~~~~~~~~~~~~~~~~
+    A method that takes `request` and creates a ZipkinAttrs object. This
+    can be used to generate span_id, parent_id or other ZipkinAttrs fields
+    based on request parameters.
+
+    The method MUST take `request` as a parametr and return a ZipkinAttrs
+    object.
+
+
+zipkin.is_tracing
+~~~~~~~~~~~~~~~~~
+    A method that takes `request` and determines if the request should be
+    traced. This can be used to determine if a request is traced based on
+    custom application specific logic.
+
+    The method MUST take `request` as a parameter and return a Boolean.
+
+
 zipkin.set_extra_binary_annotations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     A method that takes `request` and `response` objects as parameters

--- a/pyramid_zipkin/request_helper.py
+++ b/pyramid_zipkin/request_helper.py
@@ -119,6 +119,9 @@ def create_zipkin_attr(request):
     Attaches lazy attribute `zipkin_trace_id` with request which is then used
     throughout the tween.
 
+    Consumes custom is_tracing function to determine if the request is traced
+    if one is set in the pyramid registry.
+
     :param request: pyramid request object
     :rtype: :class:`pyramid_zipkin.request_helper.ZipkinAttrs`
     """

--- a/pyramid_zipkin/request_helper.py
+++ b/pyramid_zipkin/request_helper.py
@@ -125,7 +125,13 @@ def create_zipkin_attr(request):
     request.set_property(get_trace_id, 'zipkin_trace_id', reify=True)
 
     trace_id = request.zipkin_trace_id
-    is_sampled = is_tracing(request)
+
+    settings = request.registry.settings
+    if 'zipkin.is_tracing' in settings:
+        is_sampled = settings['zipkin.is_tracing'](request)
+    else:
+        is_sampled = is_tracing(request)
+
     span_id = request.headers.get(
         'X-B3-SpanId', generate_random_64bit_string())
     parent_span_id = request.headers.get('X-B3-ParentSpanId', None)

--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -21,10 +21,14 @@ def zipkin_tween(handler, registry):
     :returns: pyramid tween
     """
     def tween(request):
-        # Creates zipkin_attrs and attaches a zipkin_trace_id attr to the request
-        zipkin_attrs = create_zipkin_attr(request)
-
         settings = request.registry.settings
+
+        # Creates zipkin_attrs and attaches a zipkin_trace_id attr to the request
+        if 'zipkin.create_zipkin_attr' in settings:
+            zipkin_attrs = settings['zipkin.create_zipkin_attr'](request)
+        else:
+            zipkin_attrs = create_zipkin_attr(request)
+
         if 'zipkin.transport_handler' in settings:
             transport_handler = settings['zipkin.transport_handler']
             stream_name = settings.get('zipkin.stream_name', 'zipkin')

--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -15,6 +15,9 @@ def zipkin_tween(handler, registry):
     into threadlocal storage, so `create_http_headers_for_new_span` and
     `zipkin_span` will have access to the proper Zipkin state.
 
+    Consumes custom create_zipkin_attr function if one is set in the pyramid
+    registry.
+
     :param handler: pyramid request handler
     :param registry: pyramid app registry
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = "0.16.0"
+__version__ = "0.16.1"
 
 setup(
     name='pyramid_zipkin',

--- a/tests/request_helper_test.py
+++ b/tests/request_helper_test.py
@@ -120,6 +120,15 @@ def test_get_trace_id_returns_header_value_if_present_128_bit(dummy_request):
     assert '48485a3953bb6124' == request_helper.get_trace_id(dummy_request)
 
 
+def test_create_zipkin_attr_runs_custom_is_tracing_if_present(dummy_request):
+    is_tracing = mock.Mock(return_value=True)
+    dummy_request.registry.settings = {
+        'zipkin.is_tracing': is_tracing,
+    }
+    request_helper.create_zipkin_attr(dummy_request)
+    is_tracing.assert_called_once_with(dummy_request)
+
+
 def test_get_trace_id_runs_custom_trace_id_generator_if_present(dummy_request):
     dummy_request.registry.settings = {
         'zipkin.trace_id_generator': lambda r: '27133d482ba4f605',


### PR DESCRIPTION
support for custom versions of

create_zipkin_attr
is_tracing

this will support generating zipkin attributes and determining if a request is traced in a flexible and customized manner