### PR TITLE
Add ability to set a Pyramid registry setting to force py-zipkin add logging annotation

### DIFF
--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -52,6 +52,10 @@ def zipkin_tween(handler, registry):
             zipkin_attrs=zipkin_attrs,
             transport_handler=transport_handler,
             port=request.server_port,
+            add_logging_annotation=settings.get(
+                'zipkin.add_logging_annotation',
+                False,
+            ),
         ) as zipkin_context:
             response = handler(request)
             zipkin_context.update_binary_annotations_for_root_span(

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(exclude=('tests*',)),
     package_data={'': ['*.thrift']},
     install_requires=[
-        'py_zipkin',
+        'py_zipkin >= 0.4.4',
         'pyramid',
         'six',
     ],


### PR DESCRIPTION
Requires `py-zipkin >= 0.4.4` so I've pinned that in setup.py. Super straightforward. Added an acceptance test which is really testing `py-zipkin`'s behavior, but whatever.