### PR TITLE
Fix tests for py-zipkin 0.5.0.

### DIFF
--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -72,4 +72,7 @@ def get_span(
                 response_status_code_annotation,
             ],
             'name': 'GET /sample',
+            # An optional field for 128-bit trace IDs that py-zipkin doesn't
+            # set. See https://github.com/Yelp/py_zipkin/issues/28
+            'trace_id_high': None,
             }

--- a/tests/acceptance/test_helper.py
+++ b/tests/acceptance/test_helper.py
@@ -6,12 +6,14 @@ def get_timestamps(span):
     return timestamps
 
 
-def remove_ipv4(span):
+def remove_ip_fields(span):
     for ann in span['annotations']:
         ann['host'].pop('ipv4', None)
+        ann['host'].pop('ipv6', None)
 
     for b_ann in span['binary_annotations']:
         b_ann['host'].pop('ipv4', None)
+        b_ann['host'].pop('ipv6', None)
 
 
 def massage_result_span(span_obj):
@@ -28,7 +30,7 @@ def massage_result_span(span_obj):
         bann['host'] = bann['host'].__dict__
     span['annotations'].sort(key=lambda ann: ann['value'])
     span['binary_annotations'].sort(key=lambda ann: ann['key'])
-    remove_ipv4(span)
+    remove_ip_fields(span)
     return span
 
 


### PR DESCRIPTION
py-zipkin 0.5.0 upgrade broke some of these tests, even though it didn't break backwards compatibility for any users.