### PR TITLE
Add support for forcing the root span to report timestamp/duration

### DIFF
--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -64,7 +64,14 @@ def _get_settings_from_request(request):
         'zipkin.add_logging_annotation',
         False,
     )
-    report_root_timestamp = settings.get('zipkin.report_root_timestamp', False)
+    # If the incoming request doesn't have Zipkin headers, this request is
+    # assumed to be the root span of a trace. There's also a configuration
+    # override to allow services to write their own logic for reporting
+    # timestamp/duration.
+    if 'zipkin.report_root_timestamp' in settings:
+        report_root_timestamp = settings['zipkin.report_root_timestamp']
+    else:
+        report_root_timestamp = 'X-B3-TraceId' not in request.headers
     return ZipkinSettings(
         zipkin_attrs,
         transport_handler,

--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -1,11 +1,78 @@
 # -*- coding: utf-8 -*-
 import functools
+from collections import namedtuple
 
 from py_zipkin.exception import ZipkinError
 from py_zipkin.zipkin import zipkin_span
 
 from pyramid_zipkin.request_helper import create_zipkin_attr
 from pyramid_zipkin.request_helper import get_binary_annotations
+
+
+ZipkinSettings = namedtuple('ZipkinSettings', [
+    'zipkin_attrs',
+    'transport_handler',
+    'service_name',
+    'span_name',
+    'add_logging_annotation',
+    'report_root_timestamp',
+])
+
+
+def _get_settings_from_request(request):
+    """Extracts Zipkin attributes and configuration from request attributes.
+    See the `zipkin_span` context in py-zipkin for more detaied information on
+    all the settings.
+
+    Here are the supported Pyramid registry settings:
+
+    zipkin.create_zipkin_attr: allows the service to override the creation of
+        Zipkin attributes. For example, if you want to deterministically
+        calculate trace ID from some service-specific attributes.
+    zipkin.transport_handler: how py-zipkin will log the spans it generates.
+    zipkin.stream_name: an additional parameter to be used as the first arg
+        to the transport_handler function. A good example is a Kafka topic.
+    zipkin.add_logging_annotation: if true, the outermost span in this service
+        will have an annotation set when py-zipkin begins its logging.
+    zipkin.report_root_timestamp: if true, the outermost span in this service
+        will set its timestamp and duration attributes. Use this only if this
+        service is not going to have a corresponding client span. See
+        https://github.com/Yelp/pyramid_zipkin/issues/68
+    """
+    settings = request.registry.settings
+
+    # Creates zipkin_attrs and attaches a zipkin_trace_id attr to the request
+    if 'zipkin.create_zipkin_attr' in settings:
+        zipkin_attrs = settings['zipkin.create_zipkin_attr'](request)
+    else:
+        zipkin_attrs = create_zipkin_attr(request)
+
+    if 'zipkin.transport_handler' in settings:
+        transport_handler = settings['zipkin.transport_handler']
+        stream_name = settings.get('zipkin.stream_name', 'zipkin')
+        transport_handler = functools.partial(transport_handler, stream_name)
+    else:
+        raise ZipkinError(
+            "`zipkin.transport_handler` is a required config property, which"
+            " is missing. It is a callback method which takes a log stream"
+            " and a message as params and logs the message via scribe/kafka."
+        )
+
+    service_name = settings.get('service_name', 'unknown')
+    span_name = '{0} {1}'.format(request.method, request.path)
+    add_logging_annotation = settings.get(
+        'zipkin.add_logging_annotation',
+        False,
+    )
+    report_root_timestamp = settings.get('zipkin.report_root_timestamp', False)
+    return ZipkinSettings(
+        zipkin_attrs,
+        transport_handler,
+        service_name,
+        span_name,
+        add_logging_annotation,
+        report_root_timestamp,
+    )
 
 
 def zipkin_tween(handler, registry):
@@ -24,38 +91,16 @@ def zipkin_tween(handler, registry):
     :returns: pyramid tween
     """
     def tween(request):
-        settings = request.registry.settings
-
-        # Creates zipkin_attrs and attaches a zipkin_trace_id attr to the request
-        if 'zipkin.create_zipkin_attr' in settings:
-            zipkin_attrs = settings['zipkin.create_zipkin_attr'](request)
-        else:
-            zipkin_attrs = create_zipkin_attr(request)
-
-        if 'zipkin.transport_handler' in settings:
-            transport_handler = settings['zipkin.transport_handler']
-            stream_name = settings.get('zipkin.stream_name', 'zipkin')
-            transport_handler = functools.partial(transport_handler, stream_name)
-        else:
-            raise ZipkinError(
-                "`zipkin.transport_handler` is a required config property, which"
-                " is missing. It is a callback method which takes a log stream"
-                " and a message as params and logs the message via scribe/kafka."
-            )
-
-        service_name = request.registry.settings.get('service_name', 'unknown')
-        span_name = '{0} {1}'.format(request.method, request.path)
+        zipkin_settings = _get_settings_from_request(request)
 
         with zipkin_span(
-            service_name=service_name,
-            span_name=span_name,
-            zipkin_attrs=zipkin_attrs,
-            transport_handler=transport_handler,
+            service_name=zipkin_settings.service_name,
+            span_name=zipkin_settings.span_name,
+            zipkin_attrs=zipkin_settings.zipkin_attrs,
+            transport_handler=zipkin_settings.transport_handler,
             port=request.server_port,
-            add_logging_annotation=settings.get(
-                'zipkin.add_logging_annotation',
-                False,
-            ),
+            add_logging_annotation=zipkin_settings.add_logging_annotation,
+            report_root_timestamp=zipkin_settings.report_root_timestamp,
         ) as zipkin_context:
             response = handler(request)
             zipkin_context.update_binary_annotations_for_root_span(

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(exclude=('tests*',)),
     package_data={'': ['*.thrift']},
     install_requires=[
-        'py_zipkin >= 0.4.4',
+        'py_zipkin >= 0.6.0',
         'pyramid',
         'six',
     ],

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -1,9 +1,19 @@
+# -*- coding: utf-8 -*-
+import mock
 import pytest
 
 
 @pytest.fixture
 def default_trace_id_generator(dummy_request):
     return lambda dummy_request: '17133d482ba4f605'
+
+
+@pytest.fixture
+def thrift_obj():
+    with mock.patch(
+        'py_zipkin.logging_helper.thrift_obj_in_bytes', autospec=True
+    ) as mock_thrift_obj:
+        yield mock_thrift_obj
 
 
 @pytest.fixture

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -70,8 +70,6 @@ def get_span(
     return {'debug': False,
             'id': 1,
             'parent_id': None,
-            'duration': None,
-            'timestamp': None,
             'annotations': sorted(
                 [sr_annotation, ss_annotation],
                 key=lambda ann: ann['value'],


### PR DESCRIPTION
Also cleaned up the tween and acceptance test fixtures a bit.