### PR TITLE
Use update_binary_annotations function

### DIFF
--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -110,7 +110,7 @@ def zipkin_tween(handler, registry):
             report_root_timestamp=zipkin_settings.report_root_timestamp,
         ) as zipkin_context:
             response = handler(request)
-            zipkin_context.update_binary_annotations_for_root_span(
+            zipkin_context.update_binary_annotations(
                 get_binary_annotations(request, response),
             )
             return response

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(exclude=('tests*',)),
     package_data={'': ['*.thrift']},
     install_requires=[
-        'py_zipkin >= 0.6.0',
+        'py_zipkin >= 0.7.0',
         'pyramid',
         'six',
     ],


### PR DESCRIPTION
Yelp/py_zipkin#32 changes update_binary_annotations_for_root_span() to update_binary_annotations().

This PR just updates the name of the function and bumps the required version of py_zipkin.