### PR TITLE
Added version SHA in zipkin annotations for services that use Yelp Pyramid

### DIFF
--- a/pyramid_zipkin/request_helper.py
+++ b/pyramid_zipkin/request_helper.py
@@ -8,7 +8,6 @@ from py_zipkin.util import generate_random_64bit_string
 from py_zipkin.zipkin import ZipkinAttrs
 from pyramid.interfaces import IRoutesMapper
 
-
 DEFAULT_REQUEST_TRACING_PERCENT = 0.5
 
 
@@ -160,6 +159,8 @@ def get_binary_annotations(request, response):
         'http.uri.qs': request.path_qs,
         'response_status_code': str(response.status_code),
     }
+    if 'version' in request.registry:
+        annotations['version_SHA'] = request.registry.get('version')
     settings = request.registry.settings
     if 'zipkin.set_extra_binary_annotations' in settings:
         annotations.update(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,15 @@
-import mock
 import pytest
 
+from pyramid import testing
 from pyramid_zipkin import request_helper
+from pyramid.testing import DummyRequest
 
 
 @pytest.fixture
 def dummy_request():
-    request = mock.Mock()
-    request.registry.settings = {}
-    request.headers = {}
-    request.unique_request_id = '17133d482ba4f605'
-    request.path = 'bla'
-    return request
+    testing.setUp()
+    yield DummyRequest()
+    testing.tearDown()
 
 
 @pytest.fixture

--- a/tests/request_helper_test.py
+++ b/tests/request_helper_test.py
@@ -181,3 +181,11 @@ def test_convert_signed_hex():
         request_helper._convert_signed_hex('-0x3ab5151d76fb85e1') ==
         'c54aeae289047a1f'
     )
+
+
+def test_version_in_annotations(dummy_request):
+    dummy_request.registry['version'] = 'abc123'
+    response = mock.Mock()
+    response.status_code = 200
+    annotations = request_helper.get_binary_annotations(dummy_request, response)
+    assert 'abc123' == annotations['version_SHA']


### PR DESCRIPTION
Testing:
Unit tests
Manual test: Ran the homepage service in a docker container and linked it to yelp main running on dev box. Requested a zipkin email trace and verified that version_SHA in the homepage trace existed and matched with version used in the docker container.