### PR TITLE
Update tox.ini to support multiple ubuntu releases

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
 envlist = pre-commit, py27, py34, py35, flake8
+tox_pip_extensions_ext_pip_custom_platform = true
+tox_pip_extensions_ext_venv_update = true
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
The tox_pip_extensions_ext_pip_custom_platform and
tox_pip_extensions_ext_venv_update ensure the tests will use the right
wheels on any Ubuntu / Linux release.

Both plugins are open-sourced so they're fine to use in pyramid_zipkin.