### PR TITLE
Add support for python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: python
-python: 3.5
-env:
-- TOXENV=py27
-- TOXENV=py34
-- TOXENV=py35
-- TOXENV=py36
-- TOXENV=docs
-- TOXENV=flake8
+matrix:
+    include:
+        - python: 2.7
+          env: TOXENV=py27
+        - python: 3.4
+          env: TOXENV=py34
+        - python: 3.5
+          env: TOXENV=py35
+        - python: 3.6
+          env: TOXENV=py36
+        - python: 2.7
+          env: TOXENV=docs
+        - python: 2.7
+          env: TOXENV=flake8
 install: pip install tox coveralls
 script: tox
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
 - TOXENV=py27
 - TOXENV=py34
 - TOXENV=py35
+- TOXENV=py36
 - TOXENV=docs
 - TOXENV=flake8
 install: pip install tox coveralls

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,6 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pre-commit, py27, py34, py35, flake8
+envlist = pre-commit, py27, py34, py35, py36, flake8
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
All tests already pass on python 3.6. Let's add it to tox and to the
list of supported versions