### PR TITLE
Make pyramid_zipkin faster when the request is not sampled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,18 @@
+0.19.0 (2017-06-01)
+-------------------
+- Added zipkin.always_emit_zipkin_headers config flag.
+- Skip zipkin_span context manager if the request is not being sampled
+  to improve performance and avoid unnecessary work.
+
+0.18.2 (2017-03-06)
+-------------------
+- Using new update_binary_annotations functions from py_zipkin.
+- Requires py_zipkin >= 0.7.0
+
+0.18.1 (2017-02-06)
+-------------------
+- No changes
+
 0.18.0 (2017-02-06)
 -------------------
 - Add automatic timestamp/duration reporting for root server span. Also added

--- a/docs/source/configuring_zipkin.rst
+++ b/docs/source/configuring_zipkin.rst
@@ -145,6 +145,15 @@ zipkin.set_extra_binary_annotations
         settings['zipkin.set_extra_binary_annotations'] = set_binary_annotations
 
 
+zipkin.always_emit_zipkin_headers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Whether to forward the Zipkin's headers if the request is not being
+    sampled. Defaults to True.
+
+    Set to False if you're really concerned with performance as it'll save you
+    about 300us on every non-traced request.
+
+
 Configuring your application
 ----------------------------
 

--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -100,6 +100,11 @@ def zipkin_tween(handler, registry):
     def tween(request):
         zipkin_settings = _get_settings_from_request(request)
 
+        # If this request isn't sampled, don't go through the work
+        # of initializing the rest of the zipkin attributes
+        if not zipkin_settings.zipkin_attrs.is_sampled:
+            return handler(request)
+
         with zipkin_span(
             service_name=zipkin_settings.service_name,
             span_name=zipkin_settings.span_name,

--- a/tests/acceptance/span_context_test.py
+++ b/tests/acceptance/span_context_test.py
@@ -53,13 +53,15 @@ def test_headers_created_for_unsampled_child_span(
     mock_generate_string,
     default_trace_id_generator,
 ):
-    # Headers are still created if the span is unsampled.
+    # Headers are only added to the response if the request is sampled
     mock_generate_string.return_value = '17133d482ba4f605'
     settings = {
         'zipkin.tracing_percent': 0,
         'zipkin.trace_id_generator': default_trace_id_generator,
     }
-    _assert_headers_present(settings, is_sampled='0')
+    headers = WebTestApp(main({}, **settings)).get('/sample_child_span',
+                                                   status=200)
+    assert headers.json == {}
 
 
 def _assert_headers_present(settings, is_sampled):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,13 @@ def dummy_request():
 
 
 @pytest.fixture
+def dummy_response():
+    response = mock.Mock()
+    response.status_code = 200
+    return response
+
+
+@pytest.fixture
 def zipkin_attributes():
     return {'trace_id': '17133d482ba4f605',
             'span_id': '27133d482ba4f605',

--- a/tests/request_helper_test.py
+++ b/tests/request_helper_test.py
@@ -1,4 +1,5 @@
 import mock
+import pytest
 
 from pyramid_zipkin import request_helper
 
@@ -127,6 +128,53 @@ def test_create_zipkin_attr_runs_custom_is_tracing_if_present(dummy_request):
     }
     request_helper.create_zipkin_attr(dummy_request)
     is_tracing.assert_called_once_with(dummy_request)
+
+
+@pytest.mark.parametrize('is_sampled,emit_headers,headers_are_set', [
+    (True, True, True),
+    (True, False, True),
+    (False, True, True),
+    (False, False, False),
+    ])
+def test_create_zipkin_attr_add_headers(
+    is_sampled,
+    emit_headers,
+    headers_are_set,
+    dummy_request
+):
+    """
+    We should be setting the headers and zipkin_trace_id if the request is sampled
+    or if zipkin.always_emit_zipkin_headers is True.
+    """
+    dummy_request.registry.settings = {
+        'zipkin.is_tracing': lambda _: is_sampled,
+        'zipkin.always_emit_zipkin_headers': emit_headers,
+    }
+    attr = request_helper.create_zipkin_attr(dummy_request)
+
+    if headers_are_set:
+        assert dummy_request.set_property.call_count == 1
+        assert attr.trace_id != ''
+        assert attr.span_id != ''
+    else:
+        assert dummy_request.set_property.call_count == 0
+        assert attr.trace_id == ''
+        assert attr.span_id == ''
+    assert attr.is_sampled is is_sampled
+
+
+def test_create_zipkin_attr_emit_zipkin_headers_default_true(dummy_request):
+    """
+    We must ensure zipkin.always_emit_zipkin_headers is True by default
+    for backward compatibility.
+    """
+    dummy_request.registry.settings = {'zipkin.is_tracing': lambda _: False}
+    attr = request_helper.create_zipkin_attr(dummy_request)
+
+    assert dummy_request.set_property.call_count == 1
+    assert attr.trace_id != ''
+    assert attr.span_id != ''
+    assert attr.is_sampled is False
 
 
 def test_get_trace_id_runs_custom_trace_id_generator_if_present(dummy_request):

--- a/tests/request_helper_test.py
+++ b/tests/request_helper_test.py
@@ -130,16 +130,15 @@ def test_create_zipkin_attr_runs_custom_is_tracing_if_present(dummy_request):
     is_tracing.assert_called_once_with(dummy_request)
 
 
-@pytest.mark.parametrize('is_sampled,emit_headers,headers_are_set', [
-    (True, True, True),
-    (True, False, True),
-    (False, True, True),
-    (False, False, False),
+@pytest.mark.parametrize('is_sampled,emit_headers', [
+    (True, True),
+    (True, False),
+    (False, True),
+    (False, False),
     ])
 def test_create_zipkin_attr_add_headers(
     is_sampled,
     emit_headers,
-    headers_are_set,
     dummy_request
 ):
     """
@@ -152,7 +151,7 @@ def test_create_zipkin_attr_add_headers(
     }
     attr = request_helper.create_zipkin_attr(dummy_request)
 
-    if headers_are_set:
+    if is_sampled or emit_headers:
         assert dummy_request.set_property.call_count == 1
         assert attr.trace_id != ''
         assert attr.span_id != ''

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -1,0 +1,39 @@
+import mock
+
+from pyramid_zipkin import tween
+
+
+@mock.patch('pyramid_zipkin.tween.zipkin_span', autospec=True)
+def test_zipkin_tween_not_sampled(mock_span, dummy_request, dummy_response):
+    """
+    If the request is not sampled, we shouldn't use the
+    py_zipkin context manage
+    """
+    dummy_request.registry.settings = {
+        'zipkin.is_tracing': lambda _: False,
+        'zipkin.transport_handler': lambda _: None,
+    }
+    handler = mock.Mock()
+    handler.return_value = dummy_response
+
+    assert tween.zipkin_tween(handler, None)(dummy_request) == dummy_response
+    assert handler.call_count == 1
+    assert mock_span.call_count == 0
+
+
+@mock.patch('pyramid_zipkin.tween.zipkin_span', autospec=True)
+def test_zipkin_tween_sampled(mock_span, dummy_request, dummy_response):
+    """
+    If the request is sampled, we should wrap the handler in the
+    py_zipkin context manage
+    """
+    dummy_request.registry.settings = {
+        'zipkin.is_tracing': lambda _: True,
+        'zipkin.transport_handler': lambda _: None,
+    }
+    handler = mock.Mock()
+    handler.return_value = dummy_response
+
+    assert tween.zipkin_tween(handler, None)(dummy_request) == dummy_response
+    assert handler.call_count == 1
+    assert mock_span.call_count == 1

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -7,7 +7,7 @@ from pyramid_zipkin import tween
 def test_zipkin_tween_not_sampled(mock_span, dummy_request, dummy_response):
     """
     If the request is not sampled, we shouldn't use the
-    py_zipkin context manage
+    py_zipkin context manager
     """
     dummy_request.registry.settings = {
         'zipkin.is_tracing': lambda _: False,
@@ -25,7 +25,7 @@ def test_zipkin_tween_not_sampled(mock_span, dummy_request, dummy_response):
 def test_zipkin_tween_sampled(mock_span, dummy_request, dummy_response):
     """
     If the request is sampled, we should wrap the handler in the
-    py_zipkin context manage
+    py_zipkin context manager
     """
     dummy_request.registry.settings = {
         'zipkin.is_tracing': lambda _: True,


### PR DESCRIPTION
If the request is not sampled, there's no reason to wrap the handler
with py_zipkin's zipkin_span handler. Also, I've added a new config that
allows services to not add all zipkin headers if they're really
concerned with performance.

This should make pyramid_zipkin about 500us faster when the request is
not sasmpled.