### PR TITLE
Modified tween.py to include host and port when creating a zipkin span

### DIFF
--- a/docs/source/configuring_zipkin.rst
+++ b/docs/source/configuring_zipkin.rst
@@ -84,6 +84,16 @@ zipkin.blacklisted_routes
         'zipkin.blacklisted_routes': ['some_internal_route',]
 
 
+zipkin.host
+~~~~~~~~~~~~~~~~~~
+    The host ip that the zipkin trace will include in its report.
+
+
+zipkin.port
+~~~~~~~~~~~~~~~~~~
+    The port that the zipkin trace will include in its report.
+
+
 zipkin.stream_name
 ~~~~~~~~~~~~~~~~~~
     A log name to log Zipkin spans to. Defaults to 'zipkin'.

--- a/docs/source/configuring_zipkin.rst
+++ b/docs/source/configuring_zipkin.rst
@@ -86,12 +86,14 @@ zipkin.blacklisted_routes
 
 zipkin.host
 ~~~~~~~~~~~~~~~~~~
-    The host ip that is used for zipkin spans.
+    The host ip that is used for zipkin spans. If not given, host will be
+    automatically determined.
 
 
 zipkin.port
 ~~~~~~~~~~~~~~~~~~
-    The port that is used for zipkin spans.
+    The port that is used for zipkin spans. If not given, port will be
+    automatically determined.
 
 
 zipkin.stream_name

--- a/docs/source/configuring_zipkin.rst
+++ b/docs/source/configuring_zipkin.rst
@@ -86,12 +86,12 @@ zipkin.blacklisted_routes
 
 zipkin.host
 ~~~~~~~~~~~~~~~~~~
-    The host ip that the zipkin trace will include in its report.
+    The host ip that is used for zipkin spans.
 
 
 zipkin.port
 ~~~~~~~~~~~~~~~~~~
-    The port that the zipkin trace will include in its report.
+    The port that is used for zipkin spans.
 
 
 zipkin.stream_name

--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -17,7 +17,7 @@ ZipkinSettings = namedtuple('ZipkinSettings', [
     'add_logging_annotation',
     'report_root_timestamp',
     'host',
-    'port'
+    'port',
 ])
 
 
@@ -75,7 +75,7 @@ def _get_settings_from_request(request):
     else:
         report_root_timestamp = 'X-B3-TraceId' not in request.headers
     zipkin_host = settings.get('zipkin.host')
-    zipkin_port = settings.get('zipkin.port') or request.server_port
+    zipkin_port = settings.get('zipkin.port', request.server_port)
     return ZipkinSettings(
         zipkin_attrs,
         transport_handler,
@@ -84,7 +84,7 @@ def _get_settings_from_request(request):
         add_logging_annotation,
         report_root_timestamp,
         zipkin_host,
-        zipkin_port
+        zipkin_port,
     )
 
 

--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -16,6 +16,8 @@ ZipkinSettings = namedtuple('ZipkinSettings', [
     'span_name',
     'add_logging_annotation',
     'report_root_timestamp',
+    'host',
+    'port'
 ])
 
 
@@ -72,6 +74,8 @@ def _get_settings_from_request(request):
         report_root_timestamp = settings['zipkin.report_root_timestamp']
     else:
         report_root_timestamp = 'X-B3-TraceId' not in request.headers
+    zipkin_host = settings.get('zipkin.host')
+    zipkin_port = settings.get('zipkin.port') or request.server_port
     return ZipkinSettings(
         zipkin_attrs,
         transport_handler,
@@ -79,6 +83,8 @@ def _get_settings_from_request(request):
         span_name,
         add_logging_annotation,
         report_root_timestamp,
+        zipkin_host,
+        zipkin_port
     )
 
 
@@ -110,7 +116,8 @@ def zipkin_tween(handler, registry):
             span_name=zipkin_settings.span_name,
             zipkin_attrs=zipkin_settings.zipkin_attrs,
             transport_handler=zipkin_settings.transport_handler,
-            port=request.server_port,
+            host=zipkin_settings.host,
+            port=zipkin_settings.port,
             add_logging_annotation=zipkin_settings.add_logging_annotation,
             report_root_timestamp=zipkin_settings.report_root_timestamp,
         ) as zipkin_context:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(exclude=('tests*',)),
     package_data={'': ['*.thrift']},
     install_requires=[
-        'py_zipkin >= 0.7.0',
+        'py_zipkin >= 0.8.0',
         'pyramid',
         'six',
     ],


### PR DESCRIPTION
The changes made fixes the issue of zipkin ipv4 reporting 169.254.x.x from within docker. The change constructs a zipkin span with the host and port passed by the service calling pyramid_zipkin: tween(). If you do not pass in the host and port when creating the zipkin span, py_zipkin will try and resolve the host itself, resulting in 169.254.x.x on port 80.