### PR TITLE
Fix test by changing logging_start to logging_end because of new py_zipkin version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(exclude=('tests*',)),
     package_data={'': ['*.thrift']},
     install_requires=[
-        'py_zipkin >= 0.8.0',
+        'py_zipkin >= 0.8.1',
         'pyramid',
         'six',
     ],

--- a/tests/acceptance/span_context_test.py
+++ b/tests/acceptance/span_context_test.py
@@ -162,6 +162,6 @@ def test_add_logging_annotation(thrift_obj):
     server_span = thrift_obj.call_args[0][0]
     # Just make sure py-zipkin added an annotation for when logging started
     assert any(
-        annotation.value == 'py_zipkin.logging_start'
+        annotation.value == 'py_zipkin.logging_end'
         for annotation in server_span.annotations
     )


### PR DESCRIPTION
https://github.com/Yelp/py_zipkin/pull/47 broke a logging annotation test that checked for 'logging_start' (which was changed to 'logging_end' in the py_zipkin PR).