### PR TITLE
make tests pass with py_zipkin v0.9.0

### DIFF
--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -11,9 +11,9 @@ def default_trace_id_generator(dummy_request):
 @pytest.fixture
 def thrift_obj():
     with mock.patch(
-        'py_zipkin.logging_helper.thrift_obj_in_bytes', autospec=True
-    ) as mock_thrift_obj:
-        yield mock_thrift_obj
+        'py_zipkin.logging_helper.thrift_objs_in_bytes', autospec=True
+    ) as mock_thrift_objs:
+        yield mock_thrift_objs
 
 
 @pytest.fixture

--- a/tests/acceptance/server_span_test.py
+++ b/tests/acceptance/server_span_test.py
@@ -21,7 +21,9 @@ def test_sample_server_span_with_100_percent_tracing(
 
     old_time = time.time() * 1000000
 
-    def validate_span(span_obj):
+    def validate_span(span_objs):
+        assert len(span_objs) == 1
+        span_obj = span_objs[0]
         result_span = test_helper.massage_result_span(span_obj)
         timestamps = test_helper.get_timestamps(result_span)
         get_span['trace_id'] = unsigned_hex_to_signed_int(
@@ -54,7 +56,9 @@ def test_upstream_zipkin_headers_sampled(thrift_obj, default_trace_id_generator)
     span_hex = 'bbbbbbbbbbbbbbbb'
     parent_hex = 'cccccccccccccccc'
 
-    def validate(span):
+    def validate(span_objs):
+        assert len(span_objs) == 1
+        span = span_objs[0]
         assert span.trace_id == unsigned_hex_to_signed_int(trace_hex)
         assert span.id == unsigned_hex_to_signed_int(span_hex)
         assert span.parent_id == unsigned_hex_to_signed_int(parent_hex)
@@ -135,7 +139,10 @@ def test_server_extra_annotations_are_included(
     WebTestApp(main({}, **settings)).get('/sample_v2', status=200)
 
     assert thrift_obj.call_count == 1
-    server_span = thrift_obj.call_args[0][0]
+    server_spans = thrift_obj.call_args[0][0]
+    assert len(server_spans) == 1
+    server_span = server_spans[0]
+
     # Assert that the annotations logged via debug statements exist
     test_helper.assert_extra_annotations(
         server_span,
@@ -158,7 +165,9 @@ def test_binary_annotations(thrift_obj, default_trace_id_generator):
         'other_attr': '42',
     }
 
-    def validate_span(span_obj):
+    def validate_span(span_objs):
+        assert len(span_objs) == 1
+        span_obj = span_objs[0]
         # Assert that the only present binary_annotations are ones we expect
         expected_annotations = {
             'http.uri': '/sample',
@@ -204,7 +213,8 @@ def test_report_root_timestamp(thrift_obj, default_trace_id_generator):
 
     old_time = time.time() * 1000000
 
-    def check_for_timestamp_and_duration(span_obj):
+    def check_for_timestamp_and_duration(span_objs):
+        span_obj = span_objs[0]
         assert span_obj.timestamp > old_time
         assert span_obj.duration > 0
 
@@ -219,7 +229,9 @@ def test_host_and_port_in_span(thrift_obj, default_trace_id_generator):
         'zipkin.port': 1231,
     }
 
-    def validate_span(span_obj):
+    def validate_span(span_objs):
+        assert len(span_objs) == 1
+        span_obj = span_objs[0]
         # Assert ipv4 and port match what we expect
         expected_ipv4 = (1 << 24) | (2 << 16) | (2 << 8) | 1
         assert expected_ipv4 == span_obj.annotations[0].host.ipv4

--- a/tests/acceptance/span_context_test.py
+++ b/tests/acceptance/span_context_test.py
@@ -6,7 +6,6 @@ from tests.acceptance.test_helper import assert_extra_annotations
 from tests.acceptance.test_helper import assert_extra_binary_annotations
 
 
-@mock.patch('py_zipkin.logging_helper.thrift_obj_in_bytes', autospec=True)
 def test_log_new_client_spans(
     thrift_obj,
     default_trace_id_generator
@@ -20,11 +19,14 @@ def test_log_new_client_spans(
 
     WebTestApp(main({}, **settings)).get('/sample_v2_client', status=200)
 
-    # Ugly extraction of spans from mock thrift_obj call args
-    foo_span_args, bar_span_args, server_span_args = thrift_obj.call_args_list
-    foo_span = foo_span_args[0][0]
-    bar_span = bar_span_args[0][0]
-    server_span = server_span_args[0][0]
+    # Spans are batched as a list
+    assert thrift_obj.call_count == 1
+    span_list = thrift_obj.call_args[0][0]
+    assert len(span_list) == 3
+    foo_span = span_list[0]
+    bar_span = span_list[1]
+    server_span = span_list[2]
+
     # Some sanity checks on the new client spans
     for client_span in (foo_span, bar_span):
         assert client_span.parent_id == server_span.id
@@ -83,7 +85,6 @@ def _assert_headers_present(settings, is_sampled):
     assert expected == headers_json
 
 
-@mock.patch('py_zipkin.logging_helper.thrift_obj_in_bytes', autospec=True)
 def test_span_context(
     thrift_obj,
     default_trace_id_generator
@@ -97,12 +98,15 @@ def test_span_context(
 
     WebTestApp(main({}, **settings)).get('/span_context', status=200)
 
-    # Ugly extraction of spans from mock thrift_obj call args
+    # Spans are batched
     # The order of span logging goes from innermost (grandchild) up.
-    gc_span_args, child_span_args, server_span_args = thrift_obj.call_args_list
-    child_span = child_span_args[0][0]
-    grandchild_span = gc_span_args[0][0]
-    server_span = server_span_args[0][0]
+    assert thrift_obj.call_count == 1
+    span_list = thrift_obj.call_args[0][0]
+    assert len(span_list) == 3
+    grandchild_span = span_list[0]
+    child_span = span_list[1]
+    server_span = span_list[2]
+
     # Assert proper hierarchy
     assert child_span.parent_id == server_span.id
     assert grandchild_span.parent_id == child_span.id
@@ -128,7 +132,6 @@ def test_span_context(
     assert annotations['ss'] == annotations['cr']
 
 
-@mock.patch('py_zipkin.logging_helper.thrift_obj_in_bytes', autospec=True)
 def test_decorator(
     thrift_obj,
     default_trace_id_generator
@@ -143,23 +146,30 @@ def test_decorator(
     WebTestApp(main({}, **settings)).get('/decorator_context', status=200)
 
     # Two spans are logged - child span, then server span
-    child_span_args, server_span_args = thrift_obj.call_args_list
-    child_span = child_span_args[0][0]
-    server_span = server_span_args[0][0]
+    assert thrift_obj.call_count == 1
+    span_list = thrift_obj.call_args[0][0]
+    assert len(span_list) == 2
+    child_span = span_list[0]
+    server_span = span_list[1]
+
     # Assert proper hierarchy and annotations
     assert child_span.parent_id == server_span.id
     assert_extra_binary_annotations(child_span, {'a': '1'})
     assert child_span.name == 'my_span'
 
 
-@mock.patch('py_zipkin.logging_helper.thrift_obj_in_bytes', autospec=True)
 def test_add_logging_annotation(thrift_obj):
     settings = {
         'zipkin.tracing_percent': 100,
         'zipkin.add_logging_annotation': True,
     }
     WebTestApp(main({}, **settings)).get('/sample', status=200)
-    server_span = thrift_obj.call_args[0][0]
+
+    assert thrift_obj.call_count == 1
+    span_list = thrift_obj.call_args[0][0]
+    assert len(span_list) == 1
+    server_span = span_list[0]
+
     # Just make sure py-zipkin added an annotation for when logging started
     assert any(
         annotation.value == 'py_zipkin.logging_end'


### PR DESCRIPTION
py_zipkin v0.9.0 changes to sending spans in batches (lists). This shouldn't break pyramid_zipkin behavior, since the api is the same. However, our pyramid_zipkin tests mock out some internal methods, which did change and so they are broken.

The options to fix this are:
1. just fix the tests to work with 0.9.0, and
  a. pin against py_zipkin >= 0.9.0
  b. don't bother pinning because it is a test-only incompatibility and probably nobody is running the tests against older versions of py_zipkin

2. stop mocking out internal behavior and instead pass in a mock transport handler for tests. but this would have to accept thrift spans (and thrift structs of thrift spans), which means
  a. we'd need to do thrift decoding in pyramid_zipkin, or
  b. we'd need to expose a span/span list decoder in py_zipkin

The "best" option IMO is 2b, and i'd like to do it eventually, but it's a bit of work currently. To me, 1b is a reasonable solution for now, which is what this PR implements.

This fixes #81 