### PR TITLE
Rename http.uri.qs to http_uri_qs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Features include:
 
 * `zipkin_tracing_percent` to control the percentage of requests getting sampled.
 
-* Creates `http.uri`, `http.uri.qs`, and `status_code` binary annotations automatically for each trace.
+* Creates `http.uri`, `http_uri_qs`, and `status_code` binary annotations automatically for each trace.
 
 Install
 -------

--- a/docs/source/configuring_zipkin.rst
+++ b/docs/source/configuring_zipkin.rst
@@ -145,7 +145,7 @@ zipkin.set_extra_binary_annotations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     A method that takes `request` and `response` objects as parameters
     and produces extra binary annotations. If this config is omitted,
-    only `http.uri` and `http.uri.qs` are added as binary annotations.
+    only `http.uri` and `http_uri_qs` are added as binary annotations.
     The return value of the callback must be a dictionary, and all keys
     and values must be in `str` format. Example:
 
@@ -165,6 +165,11 @@ zipkin.always_emit_zipkin_headers
     Set to False if you're really concerned with performance as it'll save you
     about 300us on every non-traced request.
 
+zipkin.set_old_http_uri_qs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Adds http.uri.qs to binary annotation (for backward compatibility). If
+    turned on, requests made to Zipkin ES SPAN2 will be rejected.
+    Defaults to False.
 
 Configuring your application
 ----------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ Features include:
 
 * ``zipkin_tracing_percent`` to control the percentage of requests getting sampled.
 
-* Adds ``http.uri``, ``http.uri.qs``, and ``status_code`` binary annotations automatically for each trace.
+* Adds ``http.uri``, ``http_uri_qs``, and ``status_code`` binary annotations automatically for each trace.
 
 * Allows configuration of additional arbitrary binary annotations.
 

--- a/pyramid_zipkin/request_helper.py
+++ b/pyramid_zipkin/request_helper.py
@@ -164,10 +164,12 @@ def get_binary_annotations(request, response):
     """
     annotations = {
         'http.uri': request.path,
-        'http.uri.qs': request.path_qs,
+        'http_uri_qs': request.path_qs,
         'response_status_code': str(response.status_code),
     }
     settings = request.registry.settings
+    if 'zipkin.set_old_http_uri_qs' in settings:
+        annotations['http.uri.qs'] = request.path_qs
     if 'zipkin.set_extra_binary_annotations' in settings:
         annotations.update(
             settings['zipkin.set_extra_binary_annotations'](request, response)

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -43,6 +43,7 @@ def uri_binary_annotation(host):
 def uri_qs_binary_annotation(host):
     return {'key': 'http_uri_qs', 'host': host, 'annotation_type': 6}
 
+
 @pytest.fixture
 def uri_qs_binary_annotation_old(host):
     return {'key': 'http.uri.qs', 'host': host, 'annotation_type': 6}

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -41,6 +41,10 @@ def uri_binary_annotation(host):
 
 @pytest.fixture
 def uri_qs_binary_annotation(host):
+    return {'key': 'http_uri_qs', 'host': host, 'annotation_type': 6}
+
+@pytest.fixture
+def uri_qs_binary_annotation_old(host):
     return {'key': 'http.uri.qs', 'host': host, 'annotation_type': 6}
 
 

--- a/tests/acceptance/server_span_test.py
+++ b/tests/acceptance/server_span_test.py
@@ -171,9 +171,38 @@ def test_binary_annotations(thrift_obj, default_trace_id_generator):
         # Assert that the only present binary_annotations are ones we expect
         expected_annotations = {
             'http.uri': '/sample',
-            'http.uri.qs': '/sample?test=1',
+            'http_uri_qs': '/sample?test=1',
             'response_status_code': '200',
             'other': '42',
+        }
+        result_span = test_helper.massage_result_span(span_obj)
+        for ann in result_span['binary_annotations']:
+            assert ann['value'] == expected_annotations.pop(ann['key'])
+        assert len(expected_annotations) == 0
+
+    thrift_obj.side_effect = validate_span
+
+    WebTestApp(main({}, **settings)).get('/sample?test=1', status=200)
+
+    assert thrift_obj.call_count == 1
+
+def test_binary_annotations_old_qs(thrift_obj, default_trace_id_generator):
+    settings = {
+        'zipkin.tracing_percent': 100,
+        'zipkin.trace_id_generator': default_trace_id_generator,
+        'zipkin.set_old_http_uri_qs': True,
+        'other_attr': '42',
+    }
+
+    def validate_span(span_objs):
+        assert len(span_objs) == 1
+        span_obj = span_objs[0]
+        # Assert that the only present binary_annotations are ones we expect
+        expected_annotations = {
+            'http.uri': '/sample',
+            'http_uri_qs': '/sample?test=1',
+            'http.uri.qs': '/sample?test=1',
+            'response_status_code': '200',
         }
         result_span = test_helper.massage_result_span(span_obj)
         for ann in result_span['binary_annotations']:

--- a/tests/acceptance/server_span_test.py
+++ b/tests/acceptance/server_span_test.py
@@ -186,6 +186,7 @@ def test_binary_annotations(thrift_obj, default_trace_id_generator):
 
     assert thrift_obj.call_count == 1
 
+
 def test_binary_annotations_old_qs(thrift_obj, default_trace_id_generator):
     settings = {
         'zipkin.tracing_percent': 100,

--- a/tests/acceptance/test_helper.py
+++ b/tests/acceptance/test_helper.py
@@ -46,6 +46,6 @@ def assert_extra_annotations(span, annotations):
 def assert_extra_binary_annotations(span, binary_annotations):
     seen_extra_binary_annotations = dict(
         (ann.key, ann.value) for ann in span.binary_annotations
-        if ann.key not in ('http.uri', 'http.uri.qs', 'response_status_code')
+        if ann.key not in ('http.uri', 'http_uri_qs', 'response_status_code')
     )
     assert binary_annotations == seen_extra_binary_annotations


### PR DESCRIPTION
ES SPAN2 (currently experimental) fails to store traces from this
library with error:

  Can't merge a non object mapping [tags.http.uri] with an object
  mapping [tags.http.uri]

For backward compatibility, new configuration parameter is introduced.