### PR TITLE
Allow trace id to be propagated on non-sampled requests

### DIFF
--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -106,11 +106,6 @@ def zipkin_tween(handler, registry):
     def tween(request):
         zipkin_settings = _get_settings_from_request(request)
 
-        # If this request isn't sampled, don't go through the work
-        # of initializing the rest of the zipkin attributes
-        if not zipkin_settings.zipkin_attrs.is_sampled:
-            return handler(request)
-
         with zipkin_span(
             service_name=zipkin_settings.service_name,
             span_name=zipkin_settings.span_name,

--- a/tests/acceptance/span_context_test.py
+++ b/tests/acceptance/span_context_test.py
@@ -55,15 +55,13 @@ def test_headers_created_for_unsampled_child_span(
     mock_generate_string,
     default_trace_id_generator,
 ):
-    # Headers are only added to the response if the request is sampled
+    # Headers are still created if the span is unsampled
     mock_generate_string.return_value = '17133d482ba4f605'
     settings = {
         'zipkin.tracing_percent': 0,
         'zipkin.trace_id_generator': default_trace_id_generator,
     }
-    headers = WebTestApp(main({}, **settings)).get('/sample_child_span',
-                                                   status=200)
-    assert headers.json == {}
+    _assert_headers_present(settings, is_sampled='0')
 
 
 def _assert_headers_present(settings, is_sampled):

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -10,7 +10,7 @@ def test_zipkin_tween_sampling(
     mock_span,
     dummy_request,
     dummy_response,
-    is_tracing
+    is_tracing,
 ):
     """
     We should enter py_zipkin context manager and

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -1,34 +1,23 @@
 import mock
 
 from pyramid_zipkin import tween
+import pytest
 
 
+@pytest.mark.parametrize('is_tracing', [True, False])
 @mock.patch('pyramid_zipkin.tween.zipkin_span', autospec=True)
-def test_zipkin_tween_not_sampled(mock_span, dummy_request, dummy_response):
+def test_zipkin_tween_sampling(
+    mock_span,
+    dummy_request,
+    dummy_response,
+    is_tracing
+):
     """
-    If the request is not sampled, we shouldn't use the
-    py_zipkin context manager
+    We should enter py_zipkin context manager and
+    generate a trace id regardless of whether we are sampling
     """
     dummy_request.registry.settings = {
-        'zipkin.is_tracing': lambda _: False,
-        'zipkin.transport_handler': lambda _: None,
-    }
-    handler = mock.Mock()
-    handler.return_value = dummy_response
-
-    assert tween.zipkin_tween(handler, None)(dummy_request) == dummy_response
-    assert handler.call_count == 1
-    assert mock_span.call_count == 0
-
-
-@mock.patch('pyramid_zipkin.tween.zipkin_span', autospec=True)
-def test_zipkin_tween_sampled(mock_span, dummy_request, dummy_response):
-    """
-    If the request is sampled, we should wrap the handler in the
-    py_zipkin context manager
-    """
-    dummy_request.registry.settings = {
-        'zipkin.is_tracing': lambda _: True,
+        'zipkin.is_tracing': lambda _: is_tracing,
         'zipkin.transport_handler': lambda _: None,
     }
     handler = mock.Mock()


### PR DESCRIPTION
Currently, if a request is not sampled, pyramid_zipkin does not generate a trace/span id and thread local is empty. As a result, there are no headers being propagated when making downstream service calls even with the swagger_zipkin decorator.

Ref: [https://github.com/Yelp/pyramid_zipkin/blob/master/pyramid_zipkin/tween.py#L111](https://github.com/Yelp/pyramid_zipkin/blob/master/pyramid_zipkin/tween.py#L111)

This change makes it so that we enter py_zipkin's context manager regardless of whether sampling is enabled or not. py_zipkin's context manager is responsible for pushing the headers onto thread local and swagger_zipkin directly reads from there. Zipkin headers can be propagated for all requests instead of just sampled requests.

I measured the overhead of this at approximately 50us (benchmarked with `ab` with 100000 requests).