### PR TITLE
add support for firehose tracing

### DIFF
--- a/docs/source/configuring_zipkin.rst
+++ b/docs/source/configuring_zipkin.rst
@@ -166,6 +166,16 @@ zipkin.always_emit_zipkin_headers
     about 300us on every non-traced request.
 
 
+zipkin.firehose_handler [EXPERIMENTAL]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    `Requires py_zipkin >= 0.11.0`
+
+    Callback function for "firehose tracing" mode. This will log 100% of the
+    spans to this handler, regardless of sampling decision.
+
+    This is experimental and may change or be removed at any time without warning.
+
+
 Configuring your application
 ----------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,6 @@ setup(
         'pyramid',
         'six',
     ],
-    tests_require=[
-        'py_zipkin >= 0.11.0',
-    ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ setup(
         'pyramid',
         'six',
     ],
+    tests_require=[
+        'py_zipkin >= 0.11.0',
+    ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
This corresponds with the firehose tracing PR from py_zipkin (https://github.com/Yelp/py_zipkin/pull/66), which is available in 0.11.0. This is implemented as a backwards compatible change because we can't rely on `firehose_handler` necessarily being available in future releases. 

This change will error if someone tries to supply a firehose_handler with a version of py_zipkin that doesn't support it. But it will not error if you do not use it. This helps protect us from API-breaking changes in py_zipkin in the future.

I want to be able to test this, though, so i added the `tests_require` property in `setup.py`. I'm not sure if this is the best way to do this.