### PR TITLE
require py_zipkin >= 0.11.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(exclude=('tests*',)),
     package_data={'': ['*.thrift']},
     install_requires=[
-        'py_zipkin >= 0.10.1',
+        'py_zipkin >= 0.11.0',
         'pyramid',
         'six',
     ],


### PR DESCRIPTION
I tried to be backwards compatible with the firehose-mode change from 0.20.1, but it ended up making it so that users of pyramid_zipkin have to pin not only pyramid_zipkin, but also py_zipkin (an indirect dependency). This isn't great, so instead, I'm just bumping the py_zipkin requirement.

Alternatively, I think I could do something like `extras_require`, but I think this is simple enough.