### PR TITLE
add test case for 404

### DIFF
--- a/tests/acceptance/app/__init__.py
+++ b/tests/acceptance/app/__init__.py
@@ -4,7 +4,7 @@ from py_zipkin.zipkin import create_http_headers_for_new_span
 from py_zipkin.zipkin import zipkin_span
 from pyramid.config import Configurator
 from pyramid.response import Response
-from pyramid.tweens import MAIN
+from pyramid.tweens import EXCVIEW
 from pyramid.view import view_config
 
 
@@ -124,6 +124,6 @@ def main(global_config, **settings):
 
     config.scan()
 
-    config.add_tween('pyramid_zipkin.tween.zipkin_tween', over=MAIN)
+    config.add_tween('pyramid_zipkin.tween.zipkin_tween', over=EXCVIEW)
 
     return config.make_wsgi_app()


### PR DESCRIPTION
This adds a test case for 404 and fixes the acceptance test app to put the view over the EXCVIEW (like we do in `includeme`) that way the exception is converted into a response.

This closes #92 