### PR TITLE
Fix tests with new py_zipkin

### DIFF
--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -86,8 +86,8 @@ def _get_settings_from_request(request):
     else:
         raise ZipkinError(
             "`zipkin.transport_handler` is a required config property, which"
-            " is missing. It is a callback method which takes a log stream"
-            " and a message as params and logs the message via scribe/kafka."
+            " is missing. Have a look at py_zipkin's docs for how to implement"
+            " it: https://github.com/Yelp/py_zipkin#transport"
         )
 
     context_stack = _getattr_path(request, settings.get('zipkin.request_context'))

--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 import functools
+import warnings
 from collections import namedtuple
 
 import py_zipkin.stack
 from py_zipkin.exception import ZipkinError
+from py_zipkin.transport import BaseTransportHandler
 from py_zipkin.zipkin import zipkin_span
 
 from pyramid_zipkin.request_helper import create_zipkin_attr
@@ -73,8 +75,14 @@ def _get_settings_from_request(request):
 
     if 'zipkin.transport_handler' in settings:
         transport_handler = settings['zipkin.transport_handler']
-        stream_name = settings.get('zipkin.stream_name', 'zipkin')
-        transport_handler = functools.partial(transport_handler, stream_name)
+        if not isinstance(transport_handler, BaseTransportHandler):
+            warnings.warn(
+                'Using a function as transport_handler is deprecated. '
+                'Please extend py_zipkin.transport.BaseTransportHandler',
+                DeprecationWarning,
+            )
+            stream_name = settings.get('zipkin.stream_name', 'zipkin')
+            transport_handler = functools.partial(transport_handler, stream_name)
     else:
         raise ZipkinError(
             "`zipkin.transport_handler` is a required config property, which"

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -1,19 +1,10 @@
 # -*- coding: utf-8 -*-
-import mock
 import pytest
 
 
 @pytest.fixture
 def default_trace_id_generator(dummy_request):
     return lambda dummy_request: '17133d482ba4f605'
-
-
-@pytest.fixture
-def thrift_obj():
-    with mock.patch(
-        'py_zipkin.logging_helper.thrift_objs_in_bytes', autospec=True
-    ) as mock_thrift_objs:
-        yield mock_thrift_objs
 
 
 @pytest.fixture

--- a/tests/acceptance/server_span_test.py
+++ b/tests/acceptance/server_span_test.py
@@ -10,14 +10,21 @@ from webtest import TestApp as WebTestApp
 
 from .app import main
 from tests.acceptance import test_helper
+from tests.acceptance.test_helper import MockTransport
+from tests.acceptance.test_helper import decode_thrift
 
 
 def test_sample_server_span_with_100_percent_tracing(
-        thrift_obj, default_trace_id_generator, get_span):
+    default_trace_id_generator,
+    get_span,
+):
     settings = {
         'zipkin.tracing_percent': 100,
         'zipkin.trace_id_generator': default_trace_id_generator,
     }
+    transport = MockTransport()
+    app_main = main({}, **settings)
+    app_main.registry.settings['zipkin.transport_handler'] = transport
 
     old_time = time.time() * 1000000
 
@@ -38,19 +45,21 @@ def test_sample_server_span_with_100_percent_tracing(
         assert old_time <= timestamps['sr']
         assert timestamps['sr'] <= timestamps['ss']
 
-    thrift_obj.side_effect = validate_span
-
     with mock.patch(
         'pyramid_zipkin.request_helper.generate_random_64bit_string'
     ) as mock_generate_random_64bit_string:
         mock_generate_random_64bit_string.return_value = '1'
-        WebTestApp(main({}, **settings)).get('/sample', status=200)
+        WebTestApp(app_main).get('/sample', status=200)
 
-    assert thrift_obj.call_count == 1
+    assert len(transport.output) == 1
+    validate_span(decode_thrift(transport.output[0]))
 
 
-def test_upstream_zipkin_headers_sampled(thrift_obj, default_trace_id_generator):
+def test_upstream_zipkin_headers_sampled(default_trace_id_generator):
+    transport = MockTransport()
     settings = {'zipkin.trace_id_generator': default_trace_id_generator}
+    app_main = main({}, **settings)
+    app_main.registry.settings['zipkin.transport_handler'] = transport
 
     trace_hex = 'aaaaaaaaaaaaaaaa'
     span_hex = 'bbbbbbbbbbbbbbbb'
@@ -68,9 +77,7 @@ def test_upstream_zipkin_headers_sampled(thrift_obj, default_trace_id_generator)
         assert span.timestamp is None
         assert span.duration is None
 
-    thrift_obj.side_effect = validate
-
-    WebTestApp(main({}, **settings)).get(
+    WebTestApp(app_main).get(
         '/sample',
         status=200,
         headers={
@@ -82,40 +89,51 @@ def test_upstream_zipkin_headers_sampled(thrift_obj, default_trace_id_generator)
         },
     )
 
+    validate(decode_thrift(transport.output[0]))
 
-def test_unsampled_request_has_no_span(thrift_obj, default_trace_id_generator):
+
+def test_unsampled_request_has_no_span(default_trace_id_generator):
     settings = {
         'zipkin.tracing_percent': 0,
         'zipkin.trace_id_generator': default_trace_id_generator,
     }
+    transport = MockTransport()
+    app_main = main({}, **settings)
+    app_main.registry.settings['zipkin.transport_handler'] = transport
 
-    WebTestApp(main({}, **settings)).get('/sample', status=200)
+    WebTestApp(app_main).get('/sample', status=200)
 
-    assert thrift_obj.call_count == 0
+    assert len(transport.output) == 0
 
 
-def test_blacklisted_route_has_no_span(thrift_obj, default_trace_id_generator):
+def test_blacklisted_route_has_no_span(default_trace_id_generator):
     settings = {
         'zipkin.tracing_percent': 100,
         'zipkin.trace_id_generator': default_trace_id_generator,
         'zipkin.blacklisted_routes': ['sample_route'],
     }
+    transport = MockTransport()
+    app_main = main({}, **settings)
+    app_main.registry.settings['zipkin.transport_handler'] = transport
 
-    WebTestApp(main({}, **settings)).get('/sample', status=200)
+    WebTestApp(app_main).get('/sample', status=200)
 
-    assert thrift_obj.call_count == 0
+    assert len(transport.output) == 0
 
 
-def test_blacklisted_path_has_no_span(thrift_obj, default_trace_id_generator):
+def test_blacklisted_path_has_no_span(default_trace_id_generator):
     settings = {
         'zipkin.tracing_percent': 100,
         'zipkin.trace_id_generator': default_trace_id_generator,
         'zipkin.blacklisted_paths': [r'^/sample'],
     }
+    transport = MockTransport()
+    app_main = main({}, **settings)
+    app_main.registry.settings['zipkin.transport_handler'] = transport
 
-    WebTestApp(main({}, **settings)).get('/sample', status=200)
+    WebTestApp(app_main).get('/sample', status=200)
 
-    assert thrift_obj.call_count == 0
+    assert len(transport.output) == 0
 
 
 def test_no_transport_handler_throws_error():
@@ -127,19 +145,19 @@ def test_no_transport_handler_throws_error():
         WebTestApp(app_main).get('/sample', status=200)
 
 
-def test_server_extra_annotations_are_included(
-    thrift_obj,
-    default_trace_id_generator
-):
+def test_server_extra_annotations_are_included(default_trace_id_generator):
     settings = {
         'zipkin.tracing_percent': 100,
         'zipkin.trace_id_generator': default_trace_id_generator,
     }
+    transport = MockTransport()
+    app_main = main({}, **settings)
+    app_main.registry.settings['zipkin.transport_handler'] = transport
 
-    WebTestApp(main({}, **settings)).get('/sample_v2', status=200)
+    WebTestApp(app_main).get('/sample_v2', status=200)
 
-    assert thrift_obj.call_count == 1
-    server_spans = thrift_obj.call_args[0][0]
+    assert len(transport.output) == 1
+    server_spans = decode_thrift(transport.output[0])
     assert len(server_spans) == 1
     server_span = server_spans[0]
 
@@ -154,7 +172,7 @@ def test_server_extra_annotations_are_included(
     )
 
 
-def test_binary_annotations(thrift_obj, default_trace_id_generator):
+def test_binary_annotations(default_trace_id_generator):
     def set_extra_binary_annotations(dummy_request, response):
         return {'other': dummy_request.registry.settings['other_attr']}
 
@@ -164,6 +182,9 @@ def test_binary_annotations(thrift_obj, default_trace_id_generator):
         'zipkin.set_extra_binary_annotations': set_extra_binary_annotations,
         'other_attr': '42',
     }
+    transport = MockTransport()
+    app_main = main({}, **settings)
+    app_main.registry.settings['zipkin.transport_handler'] = transport
 
     def validate_span(span_objs):
         assert len(span_objs) == 1
@@ -181,18 +202,20 @@ def test_binary_annotations(thrift_obj, default_trace_id_generator):
             assert ann['value'] == expected_annotations.pop(ann['key'])
         assert len(expected_annotations) == 0
 
-    thrift_obj.side_effect = validate_span
+    WebTestApp(app_main).get('/pet/123?test=1', status=200)
 
-    WebTestApp(main({}, **settings)).get('/pet/123?test=1', status=200)
+    assert len(transport.output) == 1
+    validate_span(decode_thrift(transport.output[0]))
 
-    assert thrift_obj.call_count == 1
 
-
-def test_binary_annotations_404(thrift_obj, default_trace_id_generator):
+def test_binary_annotations_404(default_trace_id_generator):
     settings = {
         'zipkin.tracing_percent': 100,
         'zipkin.trace_id_generator': default_trace_id_generator,
     }
+    transport = MockTransport()
+    app_main = main({}, **settings)
+    app_main.registry.settings['zipkin.transport_handler'] = transport
 
     def validate_span(span_objs):
         assert len(span_objs) == 1
@@ -209,14 +232,13 @@ def test_binary_annotations_404(thrift_obj, default_trace_id_generator):
             assert ann['value'] == expected_annotations.pop(ann['key'])
         assert len(expected_annotations) == 0
 
-    thrift_obj.side_effect = validate_span
+    WebTestApp(app_main).get('/abcd?test=1', status=404)
 
-    WebTestApp(main({}, **settings)).get('/abcd?test=1', status=404)
+    assert len(transport.output) == 1
+    validate_span(decode_thrift(transport.output[0]))
 
-    assert thrift_obj.call_count == 1
 
-
-def test_custom_create_zipkin_attr(thrift_obj, default_trace_id_generator):
+def test_custom_create_zipkin_attr(default_trace_id_generator):
     custom_create_zipkin_attr = mock.Mock(return_value=ZipkinAttrs(
         trace_id='1234',
         span_id='1234',
@@ -228,17 +250,23 @@ def test_custom_create_zipkin_attr(thrift_obj, default_trace_id_generator):
     settings = {
         'zipkin.create_zipkin_attr': custom_create_zipkin_attr
     }
+    transport = MockTransport()
+    app_main = main({}, **settings)
+    app_main.registry.settings['zipkin.transport_handler'] = transport
 
-    WebTestApp(main({}, **settings)).get('/sample?test=1', status=200)
+    WebTestApp(app_main).get('/sample?test=1', status=200)
 
     assert custom_create_zipkin_attr.called
 
 
-def test_report_root_timestamp(thrift_obj, default_trace_id_generator):
+def test_report_root_timestamp(default_trace_id_generator):
     settings = {
         'zipkin.report_root_timestamp': True,
         'zipkin.tracing_percent': 100.0,
     }
+    transport = MockTransport()
+    app_main = main({}, **settings)
+    app_main.registry.settings['zipkin.transport_handler'] = transport
 
     old_time = time.time() * 1000000
 
@@ -247,16 +275,21 @@ def test_report_root_timestamp(thrift_obj, default_trace_id_generator):
         assert span_obj.timestamp > old_time
         assert span_obj.duration > 0
 
-    thrift_obj.side_effect = check_for_timestamp_and_duration
-    WebTestApp(main({}, **settings)).get('/sample', status=200)
+    WebTestApp(app_main).get('/sample', status=200)
+
+    assert len(transport.output) == 1
+    check_for_timestamp_and_duration(decode_thrift(transport.output[0]))
 
 
-def test_host_and_port_in_span(thrift_obj, default_trace_id_generator):
+def test_host_and_port_in_span(default_trace_id_generator):
     settings = {
         'zipkin.tracing_percent': 100,
         'zipkin.host': '1.2.2.1',
         'zipkin.port': 1231,
     }
+    transport = MockTransport()
+    app_main = main({}, **settings)
+    app_main.registry.settings['zipkin.transport_handler'] = transport
 
     def validate_span(span_objs):
         assert len(span_objs) == 1
@@ -266,20 +299,24 @@ def test_host_and_port_in_span(thrift_obj, default_trace_id_generator):
         assert expected_ipv4 == span_obj.annotations[0].host.ipv4
         assert 1231 == span_obj.annotations[0].host.port
 
-    thrift_obj.side_effect = validate_span
+    WebTestApp(app_main).get('/sample?test=1', status=200)
 
-    WebTestApp(main({}, **settings)).get('/sample?test=1', status=200)
-
-    assert thrift_obj.call_count == 1
+    assert len(transport.output) == 1
+    validate_span(decode_thrift(transport.output[0]))
 
 
 def test_sample_server_span_with_firehose_tracing(
-        thrift_obj, default_trace_id_generator, get_span):
+        default_trace_id_generator, get_span):
     settings = {
         'zipkin.tracing_percent': 0,
         'zipkin.trace_id_generator': default_trace_id_generator,
         'zipkin.firehose_handler': default_trace_id_generator,
     }
+    normal_transport = MockTransport()
+    firehose_transport = MockTransport()
+    app_main = main({}, **settings)
+    app_main.registry.settings['zipkin.transport_handler'] = normal_transport
+    app_main.registry.settings['zipkin.firehose_handler'] = firehose_transport
 
     old_time = time.time() * 1000000
 
@@ -300,44 +337,43 @@ def test_sample_server_span_with_firehose_tracing(
         assert old_time <= timestamps['sr']
         assert timestamps['sr'] <= timestamps['ss']
 
-    thrift_obj.side_effect = validate_span
-
     with mock.patch(
         'pyramid_zipkin.request_helper.generate_random_64bit_string'
     ) as mock_generate_random_64bit_string:
         mock_generate_random_64bit_string.return_value = '1'
-        WebTestApp(main({}, **settings)).get('/sample', status=200)
+        WebTestApp(app_main).get('/sample', status=200)
 
-    assert thrift_obj.call_count == 1
+    assert len(normal_transport.output) == 0
+    assert len(firehose_transport.output) == 1
+    validate_span(decode_thrift(firehose_transport.output[0]))
 
 
-def test_max_span_batch_size(
-    thrift_obj,
-    default_trace_id_generator,
-):
-    firehose_handler = mock.Mock()
+def test_max_span_batch_size(default_trace_id_generator):
     settings = {
         'zipkin.tracing_percent': 0,
         'zipkin.trace_id_generator': default_trace_id_generator,
-        'zipkin.firehose_handler': firehose_handler,
         'zipkin.max_span_batch_size': 1,
     }
+    normal_transport = MockTransport()
+    firehose_transport = MockTransport()
+    app_main = main({}, **settings)
+    app_main.registry.settings['zipkin.transport_handler'] = normal_transport
+    app_main.registry.settings['zipkin.firehose_handler'] = firehose_transport
 
-    WebTestApp(main({}, **settings)).get('/decorator_context', status=200)
+    WebTestApp(app_main).get('/decorator_context', status=200)
 
     # Assert the expected number of batches for two spans
-    assert thrift_obj.call_count == 2
-    assert len(thrift_obj.call_args_list) == 2
-    assert firehose_handler.call_count == 2
+    assert len(normal_transport.output) == 0
+    assert len(firehose_transport.output) == 2
 
     # Assert proper hierarchy
-    batch_one = thrift_obj.call_args_list[0][0]
+    batch_one = decode_thrift(firehose_transport.output[0])
     assert len(batch_one) == 1
-    child_span = batch_one[0][0]
+    child_span = batch_one[0]
 
-    batch_two = thrift_obj.call_args_list[1][0]
+    batch_two = decode_thrift(firehose_transport.output[1])
     assert len(batch_two) == 1
-    server_span = batch_two[0][0]
+    server_span = batch_two[0]
 
     assert child_span.parent_id == server_span.id
     assert child_span.name == 'my_span'

--- a/tests/acceptance/span_context_test.py
+++ b/tests/acceptance/span_context_test.py
@@ -4,8 +4,8 @@ from webtest import TestApp as WebTestApp
 from .app import main
 from tests.acceptance.test_helper import assert_extra_annotations
 from tests.acceptance.test_helper import assert_extra_binary_annotations
-from tests.acceptance.test_helper import MockTransport
 from tests.acceptance.test_helper import decode_thrift
+from tests.acceptance.test_helper import generate_app_main
 
 
 def test_log_new_client_spans(default_trace_id_generator):
@@ -15,9 +15,7 @@ def test_log_new_client_spans(default_trace_id_generator):
         'zipkin.tracing_percent': 100,
         'zipkin.trace_id_generator': default_trace_id_generator,
     }
-    transport = MockTransport()
-    app_main = main({}, **settings)
-    app_main.registry.settings['zipkin.transport_handler'] = transport
+    app_main, transport, _ = generate_app_main(settings)
 
     WebTestApp(app_main).get('/sample_v2_client', status=200)
 
@@ -91,9 +89,7 @@ def test_span_context(default_trace_id_generator):
         'zipkin.tracing_percent': 100,
         'zipkin.trace_id_generator': default_trace_id_generator,
     }
-    transport = MockTransport()
-    app_main = main({}, **settings)
-    app_main.registry.settings['zipkin.transport_handler'] = transport
+    app_main, transport, _ = generate_app_main(settings)
 
     WebTestApp(app_main).get('/span_context', status=200)
 
@@ -138,9 +134,7 @@ def test_decorator(default_trace_id_generator):
         'zipkin.tracing_percent': 100,
         'zipkin.trace_id_generator': default_trace_id_generator,
     }
-    transport = MockTransport()
-    app_main = main({}, **settings)
-    app_main.registry.settings['zipkin.transport_handler'] = transport
+    app_main, transport, _ = generate_app_main(settings)
 
     WebTestApp(app_main).get('/decorator_context', status=200)
 
@@ -162,9 +156,7 @@ def test_add_logging_annotation():
         'zipkin.tracing_percent': 100,
         'zipkin.add_logging_annotation': True,
     }
-    transport = MockTransport()
-    app_main = main({}, **settings)
-    app_main.registry.settings['zipkin.transport_handler'] = transport
+    app_main, transport, _ = generate_app_main(settings)
 
     WebTestApp(app_main).get('/sample', status=200)
 

--- a/tests/acceptance/test_helper.py
+++ b/tests/acceptance/test_helper.py
@@ -5,6 +5,8 @@ from thriftpy.protocol.binary import read_list_begin
 from thriftpy.protocol.binary import TBinaryProtocol
 from thriftpy.transport import TMemoryBuffer
 
+from .app import main
+
 
 class MockTransport(BaseTransportHandler):
     def __init__(self, *argv, **kwargs):
@@ -28,6 +30,16 @@ def decode_thrift(encoded_spans):
         spans.append(span_obj)
 
     return spans
+
+
+def generate_app_main(settings, firehose=False):
+    normal_transport = MockTransport()
+    firehose_transport = MockTransport()
+    app_main = main({}, **settings)
+    app_main.registry.settings['zipkin.transport_handler'] = normal_transport
+    if firehose:
+        app_main.registry.settings['zipkin.firehose_handler'] = firehose_transport
+    return app_main, normal_transport, firehose_transport
 
 
 def get_timestamps(span):


### PR DESCRIPTION
Tests were failing with the newest version of py_zipkin since some internal functions were renamed.

py_zipkin shouldn't rely on internal undocumented functions anyway. What I'm doing now is to define a fake TransportHandler and checking its output.

Another issue that I encountered is that pyramid_zipkin doesn't conform to py_zipkin's `transport_handler` API. pyramid_zipkin passes both the stream name and the message to `transport_handler`, which breaks `BaseTransportHandler`.
There isn't any good reason to do so now that you can have a TransportHandler class (and can just pass the stream_name to the constructor), so I deprecated it.