### PR TITLE
Remove zipkin logger references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.egg-info
 *.pyc
 .coverage
+.pytest_cache
 .tox
 build/
 __pycache__

--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -3,7 +3,7 @@ import functools
 import warnings
 from collections import namedtuple
 
-import py_zipkin.stack
+import py_zipkin.storage
 from py_zipkin.exception import ZipkinError
 from py_zipkin.transport import BaseTransportHandler
 from py_zipkin.zipkin import zipkin_span
@@ -92,7 +92,7 @@ def _get_settings_from_request(request):
 
     context_stack = _getattr_path(request, settings.get('zipkin.request_context'))
     if context_stack is None:
-        context_stack = py_zipkin.stack.ThreadLocalStack()
+        context_stack = py_zipkin.storage.ThreadLocalStack()
 
     service_name = settings.get('service_name', 'unknown')
     span_name = '{0} {1}'.format(request.method, request.path)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(exclude=('tests*',)),
     package_data={'': ['*.thrift']},
     install_requires=[
-        'py_zipkin >= 0.11.0',
+        'py_zipkin >= 0.13.0',
         'pyramid',
         'six',
     ],

--- a/tests/acceptance/server_span_test.py
+++ b/tests/acceptance/server_span_test.py
@@ -135,31 +135,6 @@ def test_no_transport_handler_throws_error():
         WebTestApp(app_main).get('/sample', status=200)
 
 
-def test_server_extra_annotations_are_included(default_trace_id_generator):
-    settings = {
-        'zipkin.tracing_percent': 100,
-        'zipkin.trace_id_generator': default_trace_id_generator,
-    }
-    app_main, transport, _ = generate_app_main(settings)
-
-    WebTestApp(app_main).get('/sample_v2', status=200)
-
-    assert len(transport.output) == 1
-    server_spans = decode_thrift(transport.output[0])
-    assert len(server_spans) == 1
-    server_span = server_spans[0]
-
-    # Assert that the annotations logged via debug statements exist
-    test_helper.assert_extra_annotations(
-        server_span,
-        {'bar': 1000000, 'foo': 2000000},
-    )
-    test_helper.assert_extra_binary_annotations(
-        server_span,
-        {'ping': 'pong'},
-    )
-
-
 def test_binary_annotations(default_trace_id_generator):
     def set_extra_binary_annotations(dummy_request, response):
         return {'other': dummy_request.registry.settings['other_attr']}

--- a/tests/acceptance/span_context_test.py
+++ b/tests/acceptance/span_context_test.py
@@ -106,8 +106,6 @@ def test_span_context(default_trace_id_generator):
     assert child_span.parent_id == server_span.id
     assert grandchild_span.parent_id == child_span.id
     # Assert annotations are properly assigned
-    assert_extra_annotations(server_span, {'server_annotation': 1000000})
-    assert_extra_binary_annotations(server_span, {'server': 'true'})
     assert_extra_annotations(child_span, {'child_annotation': 1000000})
     assert_extra_binary_annotations(
         child_span, {'foo': 'bar', 'child': 'true'})

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -1,7 +1,7 @@
 import collections
 
 import mock
-import py_zipkin.stack
+import py_zipkin.storage
 import pytest
 
 from pyramid_zipkin import tween
@@ -37,7 +37,7 @@ def test_zipkin_tween_sampling(
     assert mock_span.call_count == 1
 
 
-@mock.patch('py_zipkin.stack.ThreadLocalStack', autospec=True)
+@mock.patch('py_zipkin.storage.ThreadLocalStack', autospec=True)
 def test_zipkin_tween_context_stack(
     mock_thread_local_stack,
     dummy_request,
@@ -49,7 +49,7 @@ def test_zipkin_tween_context_stack(
         'zipkin.request_context': 'rctxstorage.zipkin_context',
     }
 
-    context_stack = mock.Mock(spec=py_zipkin.stack.Stack)
+    context_stack = mock.Mock(spec=py_zipkin.storage.Stack)
     dummy_request.rctxstorage = DummyRequestContext(
         zipkin_context=context_stack,
     )
@@ -62,7 +62,7 @@ def test_zipkin_tween_context_stack(
     assert context_stack.pop.call_count == 1
 
 
-@mock.patch('py_zipkin.stack.ThreadLocalStack', autospec=True)
+@mock.patch('py_zipkin.storage.ThreadLocalStack', autospec=True)
 def test_zipkin_tween_context_stack_none(
     mock_thread_local_stack,
     dummy_request,


### PR DESCRIPTION
pyramid_zipkin was using the deprecated `zipkin_logger` in its acceptance tests. The tween had already been ported to use the `zipkin_span` context manager.