### PR TITLE
Allow using the pyramid route pattern as span name.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+0.22.0 (2018-10-01)
+-------------------
+- Set `zipkin.use_pattern_as_span_name` to use the pyramid route pattern
+  as span_name rather than the raw url.
+- Requires py_zipkin >= 0.13.0.
+
 0.21.1 (2018-06-03)
 -------------------
 - Use renamed py_zipkin.storage interface

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(exclude=('tests*',)),
     package_data={'': ['*.thrift']},
     install_requires=[
-        'py_zipkin >= 0.13.0',
+        'py_zipkin >= 0.14.0',
         'pyramid',
         'six',
     ],


### PR DESCRIPTION
Using the url path as span name was a bad idea. Urls often have ids in
the path, which make the span names very high cardinality.
This makes it impossible to filter by span name in the zipkin UI and
adds pressure on the cassandra indices. The full url is anyway added as
a tag, so that information is not lost.

This defaults to False to maintain backward compatibility.