### PR TITLE
ability for a tween to invoke a callback

### DIFF
--- a/docs/source/configuring_zipkin.rst
+++ b/docs/source/configuring_zipkin.rst
@@ -190,7 +190,7 @@ zipkin.post_handler_hook
 
     .. code-block:: python
 
-        settings['zipkin.post_handler_hook'] = request.post_handler_hook
+        settings['zipkin.post_handler_hook'] = post_handler_hook
 
         def post_handler_hook(request, response):
             do_some_work(response)

--- a/docs/source/configuring_zipkin.rst
+++ b/docs/source/configuring_zipkin.rst
@@ -181,6 +181,21 @@ zipkin.request_context
         settings['zipkin.request_context'] = 'request.context.zipkin'
 
 
+zipkin.post_handler_hook
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Callback function for processing actions after the tween functionality
+    is executed and before the response is sent back.
+
+    The actions for example could be to modify the response headers.
+
+    .. code-block:: python
+
+        settings['zipkin.post_handler_hook'] = request.post_handler_hook
+
+        def post_handler_hook(request, response):
+            do_some_work(response)
+
+
 zipkin.firehose_handler [EXPERIMENTAL]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Callback function for "firehose tracing" mode. This will log 100% of the

--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -37,6 +37,7 @@ _ZipkinSettings = namedtuple('ZipkinSettings', [
     'port',
     'context_stack',
     'firehose_handler',
+    'post_processor_callback',
     'max_span_batch_size',
     'use_pattern_as_span_name',
 ])
@@ -115,6 +116,7 @@ def _get_settings_from_request(request):
     zipkin_host = settings.get('zipkin.host')
     zipkin_port = settings.get('zipkin.port', request.server_port)
     firehose_handler = settings.get('zipkin.firehose_handler')
+    post_processor_callback = settings.get('zipkin.post_processor_callback')
     max_span_batch_size = settings.get('zipkin.max_span_batch_size')
     use_pattern_as_span_name = bool(
         settings.get('zipkin.use_pattern_as_span_name', False),
@@ -130,6 +132,7 @@ def _get_settings_from_request(request):
         zipkin_port,
         context_stack,
         firehose_handler,
+        post_processor_callback,
         max_span_batch_size,
         use_pattern_as_span_name,
     )
@@ -179,6 +182,10 @@ def zipkin_tween(handler, registry):
             zipkin_context.update_binary_annotations(
                 get_binary_annotations(request, response),
             )
+
+            if zipkin_settings.post_processor_callback:
+                zipkin_settings.post_processor_callback(request, response)
+
             return response
 
     return tween

--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -37,7 +37,7 @@ _ZipkinSettings = namedtuple('ZipkinSettings', [
     'port',
     'context_stack',
     'firehose_handler',
-    'post_processor_callback',
+    'post_handler_hook',
     'max_span_batch_size',
     'use_pattern_as_span_name',
 ])
@@ -116,7 +116,7 @@ def _get_settings_from_request(request):
     zipkin_host = settings.get('zipkin.host')
     zipkin_port = settings.get('zipkin.port', request.server_port)
     firehose_handler = settings.get('zipkin.firehose_handler')
-    post_processor_callback = settings.get('zipkin.post_processor_callback')
+    post_handler_hook = settings.get('zipkin.post_handler_hook')
     max_span_batch_size = settings.get('zipkin.max_span_batch_size')
     use_pattern_as_span_name = bool(
         settings.get('zipkin.use_pattern_as_span_name', False),
@@ -132,7 +132,7 @@ def _get_settings_from_request(request):
         zipkin_port,
         context_stack,
         firehose_handler,
-        post_processor_callback,
+        post_handler_hook,
         max_span_batch_size,
         use_pattern_as_span_name,
     )
@@ -183,8 +183,8 @@ def zipkin_tween(handler, registry):
                 get_binary_annotations(request, response),
             )
 
-            if zipkin_settings.post_processor_callback:
-                zipkin_settings.post_processor_callback(request, response)
+            if zipkin_settings.post_handler_hook:
+                zipkin_settings.post_handler_hook(request, response)
 
             return response
 

--- a/tests/acceptance/server_span_test.py
+++ b/tests/acceptance/server_span_test.py
@@ -26,9 +26,9 @@ def test_sample_server_span_with_100_percent_tracing(
         'zipkin.trace_id_generator': default_trace_id_generator,
     }
 
-    mock_post_processor_callback = mock.Mock()
+    mock_post_handler_hook = mock.Mock()
     if set_callback:
-        settings['zipkin.post_processor_callback'] = mock_post_processor_callback
+        settings['zipkin.post_handler_hook'] = mock_post_handler_hook
 
     app_main, transport, _ = generate_app_main(settings)
 
@@ -59,7 +59,7 @@ def test_sample_server_span_with_100_percent_tracing(
 
     assert len(transport.output) == 1
     validate_span(decode_thrift(transport.output[0]))
-    assert mock_post_processor_callback.call_count == called
+    assert mock_post_handler_hook.call_count == called
 
 
 def test_upstream_zipkin_headers_sampled(default_trace_id_generator):
@@ -108,16 +108,16 @@ def test_unsampled_request_has_no_span(
         'zipkin.trace_id_generator': default_trace_id_generator,
     }
 
-    mock_post_processor_callback = mock.Mock()
+    mock_post_handler_hook = mock.Mock()
     if set_callback:
-        settings['zipkin.post_processor_callback'] = mock_post_processor_callback
+        settings['zipkin.post_handler_hook'] = mock_post_handler_hook
 
     app_main, transport, _ = generate_app_main(settings)
 
     WebTestApp(app_main).get('/sample', status=200)
 
     assert len(transport.output) == 0
-    assert mock_post_processor_callback.call_count == called
+    assert mock_post_handler_hook.call_count == called
 
 
 def test_blacklisted_route_has_no_span(default_trace_id_generator):

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -59,7 +59,8 @@ def test_zipkin_tween_post_processor_callback(
         'zipkin.transport_handler': lambda _: None,
     }
     if set_callback:
-        dummy_request.registry.settings['zipkin.post_processor_callback'] = mock_post_processor_callback
+        dummy_request.registry.settings['zipkin.post_processor_callback'] = \
+            mock_post_processor_callback
 
     handler = mock.Mock()
     handler.return_value = dummy_response
@@ -67,9 +68,12 @@ def test_zipkin_tween_post_processor_callback(
     assert tween.zipkin_tween(handler, None)(dummy_request) == dummy_response
     assert handler.call_count == 1
     assert mock_span.call_count == 1
-    assert mock_post_processor_callback.call_count == called 
+    assert mock_post_processor_callback.call_count == called
     if set_callback:
-        mock_post_processor_callback.assert_called_once_with(dummy_request, dummy_response)
+        mock_post_processor_callback.assert_called_once_with(
+            dummy_request,
+            dummy_response,
+        )
 
 
 @mock.patch('py_zipkin.storage.ThreadLocalStack', autospec=True)

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -37,6 +37,41 @@ def test_zipkin_tween_sampling(
     assert mock_span.call_count == 1
 
 
+@pytest.mark.parametrize(['set_callback', 'called'], [(False, 0), (True, 1)])
+@pytest.mark.parametrize('is_tracing', [True, False])
+@mock.patch('pyramid_zipkin.tween.zipkin_span', autospec=True)
+def test_zipkin_tween_post_processor_callback(
+    mock_span,
+    dummy_request,
+    dummy_response,
+    is_tracing,
+    set_callback,
+    called,
+):
+    """
+    We should invoke the post processor callback regardless of trace id
+    or sampling
+    """
+    mock_post_processor_callback = mock.Mock()
+
+    dummy_request.registry.settings = {
+        'zipkin.is_tracing': lambda _: is_tracing,
+        'zipkin.transport_handler': lambda _: None,
+    }
+    if set_callback:
+        dummy_request.registry.settings['zipkin.post_processor_callback'] = mock_post_processor_callback
+
+    handler = mock.Mock()
+    handler.return_value = dummy_response
+
+    assert tween.zipkin_tween(handler, None)(dummy_request) == dummy_response
+    assert handler.call_count == 1
+    assert mock_span.call_count == 1
+    assert mock_post_processor_callback.call_count == called 
+    if set_callback:
+        mock_post_processor_callback.assert_called_once_with(dummy_request, dummy_response)
+
+
 @mock.patch('py_zipkin.storage.ThreadLocalStack', autospec=True)
 def test_zipkin_tween_context_stack(
     mock_thread_local_stack,

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -40,7 +40,7 @@ def test_zipkin_tween_sampling(
 @pytest.mark.parametrize(['set_callback', 'called'], [(False, 0), (True, 1)])
 @pytest.mark.parametrize('is_tracing', [True, False])
 @mock.patch('pyramid_zipkin.tween.zipkin_span', autospec=True)
-def test_zipkin_tween_post_processor_callback(
+def test_zipkin_tween_post_handler_hook(
     mock_span,
     dummy_request,
     dummy_response,
@@ -52,15 +52,15 @@ def test_zipkin_tween_post_processor_callback(
     We should invoke the post processor callback regardless of trace id
     or sampling
     """
-    mock_post_processor_callback = mock.Mock()
+    mock_post_handler_hook = mock.Mock()
 
     dummy_request.registry.settings = {
         'zipkin.is_tracing': lambda _: is_tracing,
         'zipkin.transport_handler': lambda _: None,
     }
     if set_callback:
-        dummy_request.registry.settings['zipkin.post_processor_callback'] = \
-            mock_post_processor_callback
+        dummy_request.registry.settings['zipkin.post_handler_hook'] = \
+            mock_post_handler_hook
 
     handler = mock.Mock()
     handler.return_value = dummy_response
@@ -68,9 +68,9 @@ def test_zipkin_tween_post_processor_callback(
     assert tween.zipkin_tween(handler, None)(dummy_request) == dummy_response
     assert handler.call_count == 1
     assert mock_span.call_count == 1
-    assert mock_post_processor_callback.call_count == called
+    assert mock_post_handler_hook.call_count == called
     if set_callback:
-        mock_post_processor_callback.assert_called_once_with(
+        mock_post_handler_hook.assert_called_once_with(
             dummy_request,
             dummy_response,
         )


### PR DESCRIPTION
If callback is provided in the header pyramid zipkin tween will invoke a callback before executing a response. 
The use case for the such a callback would be for example a post processor that sends an email link with the zipkin trace.