### PR TITLE
Fix tests and add encoding support

### DIFF
--- a/docs/source/configuring_zipkin.rst
+++ b/docs/source/configuring_zipkin.rst
@@ -204,6 +204,14 @@ zipkin.firehose_handler [EXPERIMENTAL]
     This is experimental and may change or be removed at any time without warning.
 
 
+zipkin.encoding
+~~~~~~~~~~~~~~~
+    py-zipkin allows you to specify the output encoding for your spans. This
+    argument should be of type `py_zipkin.Encoding`.
+
+    It defaults to `Encoding.V1_THRIFT` to keep backward compatibility.
+
+
 Configuring your application
 ----------------------------
 

--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -4,6 +4,7 @@ import warnings
 from collections import namedtuple
 
 import py_zipkin.storage
+from py_zipkin import Encoding
 from py_zipkin.exception import ZipkinError
 from py_zipkin.transport import BaseTransportHandler
 from py_zipkin.zipkin import zipkin_span
@@ -40,6 +41,7 @@ _ZipkinSettings = namedtuple('ZipkinSettings', [
     'post_handler_hook',
     'max_span_batch_size',
     'use_pattern_as_span_name',
+    'encoding',
 ])
 
 
@@ -121,6 +123,7 @@ def _get_settings_from_request(request):
     use_pattern_as_span_name = bool(
         settings.get('zipkin.use_pattern_as_span_name', False),
     )
+    encoding = settings.get('zipkin.encoding', Encoding.V1_THRIFT)
     return _ZipkinSettings(
         zipkin_attrs,
         transport_handler,
@@ -135,6 +138,7 @@ def _get_settings_from_request(request):
         post_handler_hook,
         max_span_batch_size,
         use_pattern_as_span_name,
+        encoding=encoding,
     )
 
 
@@ -167,6 +171,7 @@ def zipkin_tween(handler, registry):
             report_root_timestamp=zipkin_settings.report_root_timestamp,
             context_stack=zipkin_settings.context_stack,
             max_span_batch_size=zipkin_settings.max_span_batch_size,
+            encoding=zipkin_settings.encoding,
         )
 
         if zipkin_settings.firehose_handler is not None:

--- a/tests/acceptance/app/__init__.py
+++ b/tests/acceptance/app/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from py_zipkin import Encoding
 from py_zipkin.zipkin import create_http_headers_for_new_span
 from py_zipkin.zipkin import zipkin_span
 from pyramid.config import Configurator
@@ -100,6 +101,7 @@ def main(global_config, **settings):
     """ Very basic pyramid app """
     settings['service_name'] = 'acceptance_service'
     settings['zipkin.transport_handler'] = lambda x, y: None
+    settings['zipkin.encoding'] = Encoding.V2_JSON
 
     config = Configurator(settings=settings)
 

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import mock
 import pytest
 
 
@@ -16,73 +17,23 @@ def settings():
 
 
 @pytest.fixture
-def host():
-    return {'port': 80, 'service_name': 'acceptance_service'}
-
-
-@pytest.fixture
-def annotation(host):
-    return {'host': host}
-
-
-@pytest.fixture
-def uri_binary_annotation(host):
-    return {'key': 'http.uri', 'host': host, 'annotation_type': 6}
-
-
-@pytest.fixture
-def uri_qs_binary_annotation(host):
-    return {'key': 'http.uri.qs', 'host': host, 'annotation_type': 6}
-
-
-@pytest.fixture
-def route_binary_annotation(host):
-    return {'key': 'http.route', 'host': host, 'annotation_type': 6}
-
-
-@pytest.fixture
-def response_status_code_annotation(host):
-    return {'key': 'response_status_code', 'host': host, 'annotation_type': 6}
-
-
-@pytest.fixture
-def get_span(
-    annotation,
-    uri_binary_annotation,
-    uri_qs_binary_annotation,
-    route_binary_annotation,
-    response_status_code_annotation,
-):
-    sr_annotation = annotation.copy()
-    sr_annotation['value'] = 'sr'
-
-    ss_annotation = annotation.copy()
-    ss_annotation['value'] = 'ss'
-
-    uri_binary_annotation['value'] = '/sample'
-    uri_qs_binary_annotation['value'] = '/sample'
-    route_binary_annotation['value'] = '/sample'
-
-    response_status_code_annotation['value'] = '200'
-
-    return {'debug': False,
-            'id': 1,
-            'parent_id': None,
-            'annotations': sorted(
-                [sr_annotation, ss_annotation],
-                key=lambda ann: ann['value'],
-            ),
-            'binary_annotations': sorted(
-                [
-                    uri_binary_annotation,
-                    uri_qs_binary_annotation,
-                    route_binary_annotation,
-                    response_status_code_annotation,
-                ],
-                key=lambda bann: bann['key'],
-            ),
-            'name': 'GET /sample',
-            # An optional field for 128-bit trace IDs that py-zipkin doesn't
-            # set. See https://github.com/Yelp/py_zipkin/issues/28
-            'trace_id_high': None,
-            }
+def get_span():
+    return {
+        'id': '1',
+        'tags': {
+            'http.uri': '/sample',
+            'http.uri.qs': '/sample',
+            'http.route': '/sample',
+            'response_status_code': '200',
+        },
+        'name': 'GET /sample',
+        'traceId': '17133d482ba4f605',
+        'localEndpoint': {
+            'ipv4': '127.0.0.1',
+            'port': 80,
+            'serviceName': 'acceptance_service',
+        },
+        'kind': 'SERVER',
+        'timestamp': mock.ANY,
+        'duration': mock.ANY,
+    }

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -29,7 +29,7 @@ def get_span():
         'name': 'GET /sample',
         'traceId': '17133d482ba4f605',
         'localEndpoint': {
-            'ipv4': '127.0.0.1',
+            'ipv4': mock.ANY,
             'port': 80,
             'serviceName': 'acceptance_service',
         },

--- a/tests/acceptance/test_helper.py
+++ b/tests/acceptance/test_helper.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
-from py_zipkin.thrift import zipkin_core
 from py_zipkin.transport import BaseTransportHandler
-from thriftpy.protocol.binary import read_list_begin
-from thriftpy.protocol.binary import TBinaryProtocol
-from thriftpy.transport import TMemoryBuffer
 
 from .app import main
 
@@ -20,18 +16,6 @@ class MockTransport(BaseTransportHandler):
         self.output.append(msg)
 
 
-def decode_thrift(encoded_spans):
-    spans = []
-    trans = TMemoryBuffer(encoded_spans)
-    _, size = read_list_begin(trans)
-    for _ in range(size):
-        span_obj = zipkin_core.Span()
-        span_obj.read(TBinaryProtocol(trans))
-        spans.append(span_obj)
-
-    return spans
-
-
 def generate_app_main(settings, firehose=False):
     normal_transport = MockTransport()
     firehose_transport = MockTransport()
@@ -40,60 +24,3 @@ def generate_app_main(settings, firehose=False):
     if firehose:
         app_main.registry.settings['zipkin.firehose_handler'] = firehose_transport
     return app_main, normal_transport, firehose_transport
-
-
-def get_timestamps(span):
-    timestamps = {}
-    for ann in span['annotations']:
-        timestamps[ann['value']] = ann.pop('timestamp')
-    return timestamps
-
-
-def remove_ip_fields(span):
-    for ann in span['annotations']:
-        ann['host'].pop('ipv4', None)
-        ann['host'].pop('ipv6', None)
-
-    for b_ann in span['binary_annotations']:
-        b_ann['host'].pop('ipv4', None)
-        b_ann['host'].pop('ipv6', None)
-
-
-def massage_result_span(span_obj):
-    """Remove stuff from span to make it comparable
-    """
-    # span = ast.literal_eval(str(span_obj))
-    span = span_obj.__dict__
-    span['annotations'] = [ann.__dict__ for ann in span['annotations']]
-    for ann in span['annotations']:
-        ann['host'] = ann['host'].__dict__
-    span['binary_annotations'] = [
-        bann.__dict__ for bann in span['binary_annotations']]
-    for bann in span['binary_annotations']:
-        bann['host'] = bann['host'].__dict__
-    span['annotations'].sort(key=lambda ann: ann['value'])
-    span['binary_annotations'].sort(key=lambda ann: ann['key'])
-    remove_ip_fields(span)
-    return span
-
-
-def assert_extra_annotations(span, annotations):
-    seen_extra_annotations = dict(
-        (ann.value, ann.timestamp) for ann
-        in span.annotations
-        if ann.value not in ('ss', 'sr', 'cs', 'cr')
-    )
-    assert annotations == seen_extra_annotations
-
-
-def assert_extra_binary_annotations(span, binary_annotations):
-    seen_extra_binary_annotations = dict(
-        (ann.key, ann.value) for ann in span.binary_annotations
-        if ann.key not in (
-            'http.uri',
-            'http.uri.qs',
-            'http.route',
-            'response_status_code',
-        )
-    )
-    assert binary_annotations == seen_extra_binary_annotations


### PR DESCRIPTION
Tests depend on thriftpy but don't define it as a dependency, relying on
py-zipkin to install it. Since 0.17 py-zipkin has moved to thriftpy2
and that broke our tests.
Rather than moving to thriftpy2 I changed the tests to use python since
it simplifies the logic quite a bit.