### PR TITLE
Fix tween when using py-zipkin 0.18+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(exclude=('tests*',)),
     package_data={'': ['*.thrift']},
     install_requires=[
-        'py_zipkin >= 0.14.0',
+        'py_zipkin >= 0.18.1',
         'pyramid',
         'six',
     ],


### PR DESCRIPTION
Passing in ThreadLocalStack as context_stack causes an infinite loop. Since that's the default there was never really any point in passing it.

Anyway I'm moving to the new tracer API since `ThreadLocalStack` is deprecated.