### PR TITLE
Use direct assignment rather then set_property

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+0.25.0 (2019-02-28)
+-------------------
+- Remove `zipkin.always_emit_zipkin_headers` config option. Rather than using
+  set_property to add the trace_id to the request, we now do a simple assignment
+  which is way faster and removes the need for that flag.
+
 0.24.1 (2019-02-25)
 -------------------
 - Update tween to support py-zipkin 0.18+

--- a/docs/source/configuring_zipkin.rst
+++ b/docs/source/configuring_zipkin.rst
@@ -157,15 +157,6 @@ zipkin.set_extra_binary_annotations
         settings['zipkin.set_extra_binary_annotations'] = set_binary_annotations
 
 
-zipkin.always_emit_zipkin_headers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Whether to forward the Zipkin's headers if the request is not being
-    sampled. Defaults to True.
-
-    Set to False if you're really concerned with performance as it'll save you
-    about 300us on every non-traced request.
-
-
 zipkin.request_context
 ~~~~~~~~~~~~~~~~~~~~~~
     If it contains a valid request attribute, this specifies the stack

--- a/pyramid_zipkin/request_helper.py
+++ b/pyramid_zipkin/request_helper.py
@@ -132,27 +132,19 @@ def create_zipkin_attr(request):
     else:
         is_sampled = is_tracing(request)
 
-    # If zipkin.always_emit_zipkin_headers is set to false, don't propagate
-    # zipkin headers if we're not tracing.
-    # This saves about 0.3ms since request.set_property is quite slow
-    if is_sampled or settings.get('zipkin.always_emit_zipkin_headers', True):
-        request.set_property(get_trace_id, 'zipkin_trace_id', reify=True)
+    request.zipkin_trace_id = get_trace_id(request)
 
-        trace_id = request.zipkin_trace_id
-
-        span_id = request.headers.get(
-            'X-B3-SpanId', generate_random_64bit_string())
-        parent_span_id = request.headers.get('X-B3-ParentSpanId', None)
-        flags = request.headers.get('X-B3-Flags', '0')
-        return ZipkinAttrs(
-            trace_id=trace_id,
-            span_id=span_id,
-            parent_span_id=parent_span_id,
-            flags=flags,
-            is_sampled=is_sampled,
-        )
-
-    return ZipkinAttrs('', '', '', '0', False)
+    span_id = request.headers.get(
+        'X-B3-SpanId', generate_random_64bit_string())
+    parent_span_id = request.headers.get('X-B3-ParentSpanId', None)
+    flags = request.headers.get('X-B3-Flags', '0')
+    return ZipkinAttrs(
+        trace_id=request.zipkin_trace_id,
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        flags=flags,
+        is_sampled=is_sampled,
+    )
 
 
 def get_binary_annotations(request, response):

--- a/tests/request_helper_test.py
+++ b/tests/request_helper_test.py
@@ -1,5 +1,4 @@
 import mock
-import pytest
 
 from pyramid_zipkin import request_helper
 
@@ -130,52 +129,6 @@ def test_create_zipkin_attr_runs_custom_is_tracing_if_present(dummy_request):
     is_tracing.assert_called_once_with(dummy_request)
 
 
-@pytest.mark.parametrize('is_sampled,emit_headers', [
-    (True, True),
-    (True, False),
-    (False, True),
-    (False, False),
-    ])
-def test_create_zipkin_attr_add_headers(
-    is_sampled,
-    emit_headers,
-    dummy_request
-):
-    """
-    We should be setting the headers and zipkin_trace_id if the request is sampled
-    or if zipkin.always_emit_zipkin_headers is True.
-    """
-    dummy_request.registry.settings = {
-        'zipkin.is_tracing': lambda _: is_sampled,
-        'zipkin.always_emit_zipkin_headers': emit_headers,
-    }
-    attr = request_helper.create_zipkin_attr(dummy_request)
-
-    if is_sampled or emit_headers:
-        assert dummy_request.set_property.call_count == 1
-        assert attr.trace_id != ''
-        assert attr.span_id != ''
-    else:
-        assert dummy_request.set_property.call_count == 0
-        assert attr.trace_id == ''
-        assert attr.span_id == ''
-    assert attr.is_sampled is is_sampled
-
-
-def test_create_zipkin_attr_emit_zipkin_headers_default_true(dummy_request):
-    """
-    We must ensure zipkin.always_emit_zipkin_headers is True by default
-    for backward compatibility.
-    """
-    dummy_request.registry.settings = {'zipkin.is_tracing': lambda _: False}
-    attr = request_helper.create_zipkin_attr(dummy_request)
-
-    assert dummy_request.set_property.call_count == 1
-    assert attr.trace_id != ''
-    assert attr.span_id != ''
-    assert attr.is_sampled is False
-
-
 def test_get_trace_id_runs_custom_trace_id_generator_if_present(dummy_request):
     dummy_request.registry.settings = {
         'zipkin.trace_id_generator': lambda r: '27133d482ba4f605',
@@ -205,7 +158,7 @@ def test_create_sampled_zipkin_attr_creates_ZipkinAttr_object(
         'X-B3-Flags': '45',
     }
     zipkin_attr = request_helper.ZipkinAttrs(
-        trace_id='12',
+        trace_id='0000000000000012',
         span_id='23',
         parent_span_id='34',
         flags='45',


### PR DESCRIPTION
request.set_property is relatively slow (~100 us) and it's an overkill
in our case. According to the docs it's useful since the callback is
evaluated when the property is accessed the first time rather than when
you call set_property. That saves time and cpu in case this property is
never used but:
1. we read it the next line, so we pay the penality anyway
2. this seems useful for very slow callback, while our returns almost
   immediately

Directly assigning zipkin_trace_id decreases the set time from ~100us to
~10us and the read time from ~10us to ~1us.