### PR TITLE
Fix blacklist for firehose spans

### DIFF
--- a/tests/acceptance/server_span_test.py
+++ b/tests/acceptance/server_span_test.py
@@ -119,11 +119,12 @@ def test_blacklisted_route_has_no_span(default_trace_id_generator):
         'zipkin.trace_id_generator': default_trace_id_generator,
         'zipkin.blacklisted_routes': ['sample_route'],
     }
-    app_main, transport, _ = generate_app_main(settings)
+    app_main, transport, firehose = generate_app_main(settings, firehose=True)
 
     WebTestApp(app_main).get('/sample', status=200)
 
     assert len(transport.output) == 0
+    assert len(firehose.output) == 0
 
 
 def test_blacklisted_path_has_no_span(default_trace_id_generator):
@@ -132,11 +133,12 @@ def test_blacklisted_path_has_no_span(default_trace_id_generator):
         'zipkin.trace_id_generator': default_trace_id_generator,
         'zipkin.blacklisted_paths': [r'^/sample'],
     }
-    app_main, transport, _ = generate_app_main(settings)
+    app_main, transport, firehose = generate_app_main(settings, firehose=True)
 
     WebTestApp(app_main).get('/sample', status=200)
 
     assert len(transport.output) == 0
+    assert len(firehose.output) == 0
 
 
 def test_no_transport_handler_throws_error():


### PR DESCRIPTION
Right now the blacklist works by setting `is_sampled=False`. That's useless for firehose since we emit the trace even if it's not sampled.

Given that we say that firehose is 100% of requests I was undecided on whether we wanted to emit those spans or not, but I think it makes sense to drop them. The endpoints that we blacklist are usually `/status`, `/status/metric`, `/swagger.json`, etc which aren't really interesting. And they generate a ton of traces since they're called super often by fullerite or healthchecks.