### PR TITLE
Change tween import order to be close to INGRESS

### DIFF
--- a/pyramid_zipkin/__init__.py
+++ b/pyramid_zipkin/__init__.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-from pyramid.tweens import EXCVIEW
+from pyramid.tweens import INGRESS
 
 
 def includeme(config):  # pragma: no cover
     """
     :type config: :class:`pyramid.config.Configurator`
     """
-    config.add_tween('pyramid_zipkin.tween.zipkin_tween', over=EXCVIEW)
+    config.add_tween('pyramid_zipkin.tween.zipkin_tween', under=INGRESS)

--- a/tests/acceptance/server_span_test.py
+++ b/tests/acceptance/server_span_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-import time
 import json
+import time
 
 import mock
 import pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pre-commit, py27, py35, py36, py37, flake8
+envlist = pre-commit, py27, py35, py36, py37, flake8, pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt
@@ -10,9 +10,8 @@ commands =
 
 [testenv:pre-commit]
 basepython = python3.7
-# Remove version contraint once https://gitlab.com/python-devs/importlib_resources/issues/67 is solved
-deps = pre-commit<1.12.0
-commands = pre-commit {posargs}
+deps = pre-commit
+commands = pre-commit {posargs:run --all-files}
 
 [testenv:flake8]
 basepython = python3.7


### PR DESCRIPTION
We want the zipkin tween to be close to INGRESS so that it'll also wrap
all other tweens. under INGRESS implicitly also implies over=EXCVIEW
since INGRESS is before EXCVIEW.