### PR TITLE
Update the docs to remove 100% tracing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Features include:
 
 * Blacklisting specific route/paths from getting traced.
 
-* `zipkin_tracing_percent` to control the percentage of requests getting sampled.
+* `zipkin_tracing_percent` to control the percentage of requests getting sampled (starting at, and downstream from, this service).
 
 * Creates `http.uri`, `http.uri.qs`, and `status_code` binary annotations automatically for each trace.
 

--- a/docs/source/configuring_zipkin.rst
+++ b/docs/source/configuring_zipkin.rst
@@ -104,11 +104,17 @@ zipkin.stream_name
 zipkin.tracing_percent
 ~~~~~~~~~~~~~~~~~~~~~~
     A number between 0.0 and 100.0 to control how many request calls get sampled.
+
+    .. note::
+      When your service is traced according to the tracing percentage, the
+      resulting trace will start at your service and will not include any upstream
+      clients.
+
     Defaults to `0.50`. Example:
 
     .. code-block:: python
 
-        'zipkin.tracing_percent': 100.0  # Trace all the calls.
+        'zipkin.tracing_percent': 1.0  # Increase tracing probability to 1%
 
 
 zipkin.trace_id_generator


### PR DESCRIPTION
This also clarifies a bit that upstream spans will be missing when this is used.


Testing: `make docs` output looks good.