### PR TITLE
add zipkin_span argument to post_handker_hook

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+1.0.0 (2021-10-27)
+-------------------
+- The post_handler_hook api is changed to pass the zipkin_span context
+  so users can add more content to the span during post processing
+
 0.27.0 (2020-04-07)
 -------------------
 - Change tween ordering to be close to INGRESS rather than EXCVIEW

--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -196,7 +196,7 @@ def zipkin_tween(handler, registry):
             )
 
             if zipkin_settings.post_handler_hook:
-                zipkin_settings.post_handler_hook(request, response)
+                zipkin_settings.post_handler_hook(request, response, zipkin_context)
 
             return response
 

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -75,6 +75,7 @@ def test_zipkin_tween_post_handler_hook(
         mock_post_handler_hook.assert_called_once_with(
             dummy_request,
             dummy_response,
+            mock_span.return_value.__enter__.return_value,
         )
 
 


### PR DESCRIPTION
This allows users to add more context to the zipkin_span once the request has been processed

The follow up change (motivation to do this ^^) will be to modify the default post_handler_hook here:
https://sourcegraph.yelpcorp.com/python-packages/yelp_zipkin_utils/-/blob/yelp_zipkin_utils/pyramid/zipkin_tween.py#L73:5

to make this change:
https://fluffy.yelpcorp.com/i/MVVWgMxNGqT4CbPXwjSHPBpHKS2tZdCs.html

Investigation ticket: https://jira.yelpcorp.com/browse/PEOBS-2452
