### PR TITLE
use https over unathenticated git protocol for installing pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
--   repo: git://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     sha: v0.9.1
     hooks:
     -   id: trailing-whitespace


### PR DESCRIPTION
https://jenkins-george.yelpcorp.com/job/mirrors-Yelp-pyramid_zipkin/892/execution/node/99/log/

Error: The unauthenticated git protocol on port 9418 is no longer supported