### PR TITLE
[CLIENTOBS-210] Use V2_JSON zipkin encoding by default

### DIFF
--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -127,7 +127,7 @@ def _get_settings_from_request(request: Request) -> _ZipkinSettings:
     use_pattern_as_span_name = bool(
         settings.get('zipkin.use_pattern_as_span_name', False),
     )
-    encoding = settings.get('zipkin.encoding', Encoding.V1_THRIFT)
+    encoding = settings.get('zipkin.encoding', Encoding.V2_JSON)
     return _ZipkinSettings(
         zipkin_attrs,
         transport_handler,


### PR DESCRIPTION
V2_JSON is preferred as a default encoding.