### PR TITLE
set response status code in zipkin spans during exceptions

### DIFF
--- a/pyramid_zipkin/request_helper.py
+++ b/pyramid_zipkin/request_helper.py
@@ -171,8 +171,10 @@ def get_binary_annotations(
         'http.uri': request.path,
         'http.uri.qs': request.path_qs,
         'http.route': route,
-        'response_status_code': str(response.status_code),
     }
+    if response:
+        annotations['response_status_code'] = str(response.status_code)
+
     settings = request.registry.settings
     if 'zipkin.set_extra_binary_annotations' in settings:
         annotations.update(

--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -192,22 +192,32 @@ def zipkin_tween(handler: Handler, registry: Registry) -> Handler:
             tween_kwargs['firehose_handler'] = zipkin_settings.firehose_handler
 
         with tracer.zipkin_span(**tween_kwargs) as zipkin_context:
-            response = handler(request)
-            if zipkin_settings.use_pattern_as_span_name and request.matched_route:
-                zipkin_context.override_span_name('{} {}'.format(
-                    request.method,
-                    request.matched_route.pattern,
-                ))
-            zipkin_context.update_binary_annotations(
-                get_binary_annotations(request, response),
-            )
-
-            if zipkin_settings.post_handler_hook:
-                zipkin_settings.post_handler_hook(
-                    request,
-                    response,
-                    zipkin_context
+            try:
+                response = None
+                response = handler(request)
+            except Exception as e:
+                zipkin_context.update_binary_annotations({
+                    'error_type': type(e).__name__,
+                    'response_status_code': '500'
+                })
+                raise e
+            finally:
+                if zipkin_settings.use_pattern_as_span_name \
+                        and request.matched_route:
+                    zipkin_context.override_span_name('{} {}'.format(
+                        request.method,
+                        request.matched_route.pattern,
+                    ))
+                zipkin_context.update_binary_annotations(
+                    get_binary_annotations(request, response),
                 )
+
+                if zipkin_settings.post_handler_hook:
+                    zipkin_settings.post_handler_hook(
+                        request,
+                        response,
+                        zipkin_context
+                    )
 
             return response
 

--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -197,7 +197,7 @@ def zipkin_tween(handler: Handler, registry: Registry) -> Handler:
                 response = handler(request)
             except Exception as e:
                 zipkin_context.update_binary_annotations({
-                    'error_type': type(e).__name__,
+                    'error.type': type(e).__name__,
                     'response_status_code': '500'
                 })
                 raise e

--- a/pyramid_zipkin/tween.py
+++ b/pyramid_zipkin/tween.py
@@ -192,8 +192,8 @@ def zipkin_tween(handler: Handler, registry: Registry) -> Handler:
             tween_kwargs['firehose_handler'] = zipkin_settings.firehose_handler
 
         with tracer.zipkin_span(**tween_kwargs) as zipkin_context:
+            response = None
             try:
-                response = None
                 response = handler(request)
             except Exception as e:
                 zipkin_context.update_binary_annotations({

--- a/tests/acceptance/test_helper.py
+++ b/tests/acceptance/test_helper.py
@@ -18,7 +18,7 @@ class MockTransport(BaseTransportHandler):
         """Returns the encoded spans that were sent.
 
         Spans are batched before being sent, so most of the time the returned
-        list will contain only one element. Each element is gonna be an encoded
+        list will contain only one element. Each element is going to be an encoded
         list of spans.
         """
         return self.output

--- a/tests/acceptance/test_helper.py
+++ b/tests/acceptance/test_helper.py
@@ -11,8 +11,17 @@ class MockTransport(BaseTransportHandler):
     def get_max_payload_bytes(self):
         return None
 
-    def send(self, msg):
-        self.output.append(msg)
+    def send(self, payload):
+        self.output.append(payload)
+
+    def get_payloads(self):
+        """Returns the encoded spans that were sent.
+
+        Spans are batched before being sent, so most of the time the returned
+        list will contain only one element. Each element is gonna be an encoded
+        list of spans.
+        """
+        return self.output
 
 
 def generate_app_main(settings, firehose=False):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from pyramid_zipkin import request_helper
+from pyramid.request import Request
 
 
 @pytest.fixture
@@ -14,6 +15,14 @@ def dummy_request():
     request.path = 'bla'
     return request
 
+@pytest.fixture
+def get_request():
+    request = Request.blank('GET /sample')
+    request.registry = mock.Mock()
+    request.registry.settings = {}
+    request.headers = {}
+    request.unique_request_id = '17133d482ba4f605'
+    return request
 
 @pytest.fixture
 def dummy_response():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 from unittest import mock
 
 import pytest
+from pyramid.request import Request
 
 from pyramid_zipkin import request_helper
-from pyramid.request import Request
 
 
 @pytest.fixture
@@ -15,6 +15,7 @@ def dummy_request():
     request.path = 'bla'
     return request
 
+
 @pytest.fixture
 def get_request():
     request = Request.blank('GET /sample')
@@ -23,6 +24,7 @@ def get_request():
     request.headers = {}
     request.unique_request_id = '17133d482ba4f605'
     return request
+
 
 @pytest.fixture
 def dummy_response():

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -1,4 +1,5 @@
 import collections
+import json
 from unittest import mock
 
 import pytest
@@ -77,6 +78,80 @@ def test_zipkin_tween_post_handler_hook(
             dummy_response,
             mock_span.return_value.__enter__.return_value,
         )
+
+@pytest.mark.parametrize(['set_callback', 'called'], [(False, 0), (True, 1)])
+@pytest.mark.parametrize('is_tracing', [True])
+def test_zipkin_tween_exception(
+    get_request,
+    dummy_response,
+    is_tracing,
+    set_callback,
+    called,
+):
+    """
+    If request processing throws an exception verify response_status_code = 500 is being set
+    """
+
+    mock_post_handler_hook = mock.Mock()
+    transport = MockTransport()
+
+    get_request.registry.settings = {
+        'zipkin.is_tracing': lambda _: is_tracing,
+        'zipkin.transport_handler': transport,
+    }
+    if set_callback:
+        get_request.registry.settings['zipkin.post_handler_hook'] = \
+            mock_post_handler_hook
+
+    handler = mock.Mock(side_effect=Exception)
+
+    try:
+        tween.zipkin_tween(handler, dummy_response)(get_request)
+        pytest.fail('exception was expected to be thrown')
+    except Exception as e:
+        pass
+
+    spans = transport.get_payloads()
+    assert len(spans) == 1
+    span = json.loads(spans[0])[0]
+    span['tags']['response_status_code'] = '500'
+    span['tags']['error_type'] = 'Exception'
+
+    assert handler.call_count == 1
+    assert mock_post_handler_hook.call_count == called
+
+
+@pytest.mark.parametrize(['set_callback', 'called'], [(False, 0), (True, 1)])
+@pytest.mark.parametrize('is_tracing', [True])
+def test_zipkin_tween_no_exception(
+    get_request,
+    dummy_response,
+    is_tracing,
+    set_callback,
+    called,
+):
+    mock_post_handler_hook = mock.Mock()
+    transport = MockTransport()
+
+    get_request.registry.settings = {
+        'zipkin.is_tracing': lambda _: is_tracing,
+        'zipkin.transport_handler': transport,
+    }
+    if set_callback:
+        get_request.registry.settings['zipkin.post_handler_hook'] = \
+            mock_post_handler_hook
+
+    handler = mock.Mock()
+    tween.zipkin_tween(handler, dummy_response)(get_request)
+
+    spans = transport.get_payloads()
+    assert len(spans) == 1
+    span = json.loads(spans[0])[0]
+    span = decoded_spans[0]
+    span['tags']['response_status_code'] = '200'
+
+    assert handler.call_count == 1
+    assert mock_post_handler_hook.call_count == called
 
 
 def test_zipkin_tween_context_stack(

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -109,7 +109,7 @@ def test_zipkin_tween_exception(
     try:
         tween.zipkin_tween(handler, dummy_response)(get_request)
         pytest.fail('exception was expected to be thrown!')
-    except:
+    except Exception:
         pass
 
     spans = transport.get_payloads()

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -116,7 +116,7 @@ def test_zipkin_tween_exception(
     assert len(spans) == 1
     span = json.loads(spans[0])[0]
     span['tags']['response_status_code'] = '500'
-    span['tags']['error_type'] = 'Exception'
+    span['tags']['error.type'] = 'Exception'
 
     assert handler.call_count == 1
     assert mock_post_handler_hook.call_count == called

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -79,6 +79,7 @@ def test_zipkin_tween_post_handler_hook(
             mock_span.return_value.__enter__.return_value,
         )
 
+
 @pytest.mark.parametrize(['set_callback', 'called'], [(False, 0), (True, 1)])
 @pytest.mark.parametrize('is_tracing', [True])
 def test_zipkin_tween_exception(
@@ -89,7 +90,7 @@ def test_zipkin_tween_exception(
     called,
 ):
     """
-    If request processing throws an exception verify response_status_code = 500 is being set
+    If request processing has an exception set response_status_code to 500
     """
 
     mock_post_handler_hook = mock.Mock()
@@ -107,8 +108,8 @@ def test_zipkin_tween_exception(
 
     try:
         tween.zipkin_tween(handler, dummy_response)(get_request)
-        pytest.fail('exception was expected to be thrown')
-    except Exception as e:
+        pytest.fail('exception was expected to be thrown!')
+    except:
         pass
 
     spans = transport.get_payloads()
@@ -147,7 +148,6 @@ def test_zipkin_tween_no_exception(
     spans = transport.get_payloads()
     assert len(spans) == 1
     span = json.loads(spans[0])[0]
-    span = decoded_spans[0]
     span['tags']['response_status_code'] = '200'
 
     assert handler.call_count == 1


### PR DESCRIPTION
When request processing has exceptions, the zipkin tween will now catch this exception (and re-raise it). Handling this exception in the zipkin tween lets us set the response_status_code (and error_type). This will be useful as SERVER side spans are using for analysis

Tested:
Code change to simulate the error: https://fluffy.yelpcorp.com/i/BrBMl9576HPCwvJBwPHsD4N6Gw5g8RSw.html
Test endpoint: https://www.amokal-example-happyhour-uwsgi.dev.yelp.com/hours/1234567890/v1?zipkin_email=amokal@yelp.com
Trace: https://fluffy.yelpcorp.com/i/1mFnjTRXmFhMWPz3sSWfnmTVD8Dq6lXx.html
![after](https://github.com/Yelp/pyramid_zipkin/assets/1016152/6ed9fd2e-ae29-4d23-94b6-37cdb6326eab)



