### PR TITLE
remove py11 and py12 from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pre-commit, py38, py310, py311, py312, flake8, pre-commit
+envlist = pre-commit, py38, py310, flake8, pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
Due to failure in internal jenkins repository with py11 and py12 not found. 
Keep github workflows for testing with the newer python versions 